### PR TITLE
Feat fragment

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,11 +50,6 @@ lazy val `shared` = crossProject(JSPlatform, JVMPlatform)
       "org.scalacheck" %%% "scalacheck" % "1.14.3" % "test"
     )
   )
-  .jsSettings(
-    libraryDependencies ++= List(
-      "org.scala-js" %%% "scalajs-dom" % "0.9.8"
-    )
-  )
 
 val sharedJvm = shared.jvm
 val sharedJS = shared.js

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ organization := "be.doeraene"
 
 inThisBuild(
   Def.settings(
-    version := "0.2.0",
+    version := "0.3.0",
     crossScalaVersions := Seq("2.13.1", "2.12.10"),
     scalaVersion := crossScalaVersions.value.head,
     scalacOptions ++= Seq("-feature", "-deprecation")

--- a/shared/.js/src/main/scala/urldsl/url/DefaultUrlParserGenerator.scala
+++ b/shared/.js/src/main/scala/urldsl/url/DefaultUrlParserGenerator.scala
@@ -2,7 +2,7 @@ package urldsl.url
 
 trait DefaultUrlParserGenerator {
 
-  final val defaultUrlStringParserGenerator: UrlStringParserGenerator =
+  protected final val defaultUrlStringParserGenerator0: UrlStringParserGenerator =
     JSUrlStringParser.jsUrlStringParserGenerator
 
 }

--- a/shared/.js/src/main/scala/urldsl/url/DefaultUrlStringDecoder.scala
+++ b/shared/.js/src/main/scala/urldsl/url/DefaultUrlStringDecoder.scala
@@ -4,7 +4,7 @@ import scala.scalajs.js
 
 trait DefaultUrlStringDecoder {
 
-  val defaultDecoder: UrlStringDecoder = (str: String, _: String) =>
+  protected final val defaultDecoder0: UrlStringDecoder = (str: String, _: String) =>
     js.Dynamic.global.applyDynamic("decodeURIComponent")(str).toString
 
 }

--- a/shared/.js/src/main/scala/urldsl/url/DefaultUrlStringGenerator.scala
+++ b/shared/.js/src/main/scala/urldsl/url/DefaultUrlStringGenerator.scala
@@ -4,7 +4,7 @@ import scala.scalajs.js
 
 trait DefaultUrlStringGenerator {
 
-  val default: UrlStringGenerator = (str: String, _: String) =>
+  protected val default0: UrlStringGenerator = (str: String, _: String) =>
     js.Dynamic.global.applyDynamic("encodeURIComponent")(str).toString
 
 }

--- a/shared/.js/src/main/scala/urldsl/url/JSUrlStringParser.scala
+++ b/shared/.js/src/main/scala/urldsl/url/JSUrlStringParser.scala
@@ -12,7 +12,17 @@ final class JSUrlStringParser(val rawUrl: String) extends UrlStringParser {
 
   def path: String = urlParser.pathname
 
+  def maybeFragment: Option[String] =
+    Option(urlParser.hash)
+    /*
+       * If the ref is empty and the url does not end with #, then there was no fragment at all.
+       * We do this to match exactly the JVM's behavior which, in my opinion, seems better since it gives
+       * more information about the url.
+       */
+      .filterNot(ref => ref.isEmpty && !rawUrl.endsWith("#"))
+
   def decode(str: String, encoding: String): String = js.Dynamic.global.applyDynamic("decodeURIComponent")(str).toString
+
 }
 
 object JSUrlStringParser {

--- a/shared/.js/src/main/scala/urldsl/url/JSUrlStringParser.scala
+++ b/shared/.js/src/main/scala/urldsl/url/JSUrlStringParser.scala
@@ -1,7 +1,5 @@
 package urldsl.url
 
-import org.scalajs.dom.experimental.URL
-
 import scala.scalajs.js
 
 final class JSUrlStringParser(val rawUrl: String) extends UrlStringParser {

--- a/shared/.js/src/main/scala/urldsl/url/JSUrlStringParser.scala
+++ b/shared/.js/src/main/scala/urldsl/url/JSUrlStringParser.scala
@@ -15,11 +15,10 @@ final class JSUrlStringParser(val rawUrl: String) extends UrlStringParser {
   def maybeFragment: Option[String] =
     Option(urlParser.hash)
     /*
-       * If the ref is empty and the url does not end with #, then there was no fragment at all.
-       * We do this to match exactly the JVM's behavior which, in my opinion, seems better since it gives
-       * more information about the url.
+       * Empty fragment are considered to have no fragment at all
        */
-      .filterNot(ref => ref.isEmpty && !rawUrl.endsWith("#"))
+      .filter(_.nonEmpty)
+      .map(_.drop(1)) // remove the # symbol
 
   def decode(str: String, encoding: String): String = js.Dynamic.global.applyDynamic("decodeURIComponent")(str).toString
 

--- a/shared/.js/src/main/scala/urldsl/url/URL.scala
+++ b/shared/.js/src/main/scala/urldsl/url/URL.scala
@@ -1,0 +1,31 @@
+package urldsl.url
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSGlobal
+
+/** This is stolen from org.scalajs.dom so that we don't need to import the whole library. */
+@js.native
+@JSGlobal
+final class URL(url: String) extends js.Object {
+
+  /**
+    * Is a DOMString containing an initial '/' followed by the path of the URL.
+    *
+    * MDN
+    */
+  var pathname: String = js.native
+
+  /**
+    * Is a DOMString containing a '?' followed by the parameters of the URL.
+    *
+    * MDN
+    */
+  var search: String = js.native
+
+  /**
+    * Is a DOMString containing a '#' followed by the fragment identifier of the URL.
+    *
+    * MDN
+    */
+  var hash: String = js.native
+}

--- a/shared/.jvm/src/main/scala/urldsl/url/DefaultUrlParserGenerator.scala
+++ b/shared/.jvm/src/main/scala/urldsl/url/DefaultUrlParserGenerator.scala
@@ -2,7 +2,7 @@ package urldsl.url
 
 trait DefaultUrlParserGenerator {
 
-  final val defaultUrlStringParserGenerator: UrlStringParserGenerator =
+  protected final val defaultUrlStringParserGenerator0: UrlStringParserGenerator =
     JavaNetUrlStringParser.javaNetUrlStringParserGenerator
 
 }

--- a/shared/.jvm/src/main/scala/urldsl/url/DefaultUrlStringDecoder.scala
+++ b/shared/.jvm/src/main/scala/urldsl/url/DefaultUrlStringDecoder.scala
@@ -2,6 +2,7 @@ package urldsl.url
 
 trait DefaultUrlStringDecoder {
 
-  val defaultDecoder: UrlStringDecoder = (str: String, encoding: String) => java.net.URLDecoder.decode(str, encoding)
+  protected final val defaultDecoder0: UrlStringDecoder = (str: String, encoding: String) =>
+    java.net.URLDecoder.decode(str, encoding)
 
 }

--- a/shared/.jvm/src/main/scala/urldsl/url/DefaultUrlStringGenerator.scala
+++ b/shared/.jvm/src/main/scala/urldsl/url/DefaultUrlStringGenerator.scala
@@ -2,7 +2,7 @@ package urldsl.url
 
 trait DefaultUrlStringGenerator {
 
-  val default: UrlStringGenerator = (str: String, encoding: String) =>
+  protected val default0: UrlStringGenerator = (str: String, encoding: String) =>
     java.net.URLEncoder
       .encode(str, encoding)
       .replaceAll("\\+", "%20")

--- a/shared/.jvm/src/main/scala/urldsl/url/JavaNetUrlStringParser.scala
+++ b/shared/.jvm/src/main/scala/urldsl/url/JavaNetUrlStringParser.scala
@@ -6,7 +6,7 @@ final class JavaNetUrlStringParser(val rawUrl: String) extends UrlStringParser {
 
   private val urlParser = new URL(rawUrl)
 
-  def queryParametersString: String = urlParser.getQuery
+  def queryParametersString: String = Option(urlParser.getQuery).getOrElse("")
 
   def path: String = urlParser.getPath
 

--- a/shared/.jvm/src/main/scala/urldsl/url/JavaNetUrlStringParser.scala
+++ b/shared/.jvm/src/main/scala/urldsl/url/JavaNetUrlStringParser.scala
@@ -10,6 +10,9 @@ final class JavaNetUrlStringParser(val rawUrl: String) extends UrlStringParser {
 
   def path: String = urlParser.getPath
 
+  /* getRef method of URL returns null if # is not present. */
+  def maybeFragment: Option[String] = Option(urlParser.getRef)
+
   def decode(str: String, encoding: String): String = URLDecoder.decode(str, encoding)
 }
 

--- a/shared/.jvm/src/main/scala/urldsl/url/JavaNetUrlStringParser.scala
+++ b/shared/.jvm/src/main/scala/urldsl/url/JavaNetUrlStringParser.scala
@@ -11,7 +11,7 @@ final class JavaNetUrlStringParser(val rawUrl: String) extends UrlStringParser {
   def path: String = urlParser.getPath
 
   /* getRef method of URL returns null if # is not present. */
-  def maybeFragment: Option[String] = Option(urlParser.getRef)
+  def maybeFragment: Option[String] = Option(urlParser.getRef).filter(_.nonEmpty)
 
   def decode(str: String, encoding: String): String = URLDecoder.decode(str, encoding)
 }

--- a/shared/src/main/scala/urldsl/errors/DummyError.scala
+++ b/shared/src/main/scala/urldsl/errors/DummyError.scala
@@ -8,7 +8,7 @@ sealed trait DummyError
 
 object DummyError {
 
-  final val dummyError: DummyError = new DummyError {}
+  object dummyError extends DummyError
 
   implicit final lazy val dummyErrorIsParamMatchingError: ParamMatchingError[DummyError] =
     new ParamMatchingError[DummyError] {

--- a/shared/src/main/scala/urldsl/errors/DummyError.scala
+++ b/shared/src/main/scala/urldsl/errors/DummyError.scala
@@ -36,6 +36,7 @@ object DummyError {
     new FragmentMatchingError[DummyError] {
       def missingFragmentError: DummyError = dummyError
       def wrongValue[T](actual: T, expected: T): DummyError = dummyError
+      def fragmentWasPresent(value: String): DummyError = dummyError
     }
 
   implicit final lazy val dummyErrorIsFromThrowable: ErrorFromThrowable[DummyError] = (_: Throwable) => dummyError

--- a/shared/src/main/scala/urldsl/errors/DummyError.scala
+++ b/shared/src/main/scala/urldsl/errors/DummyError.scala
@@ -32,6 +32,12 @@ object DummyError {
       def unit: DummyError = dummyError
     }
 
+  implicit lazy val dummyErrorIsFragmentMatchingError: FragmentMatchingError[DummyError] =
+    new FragmentMatchingError[DummyError] {
+      def missingFragmentError: DummyError = dummyError
+      def wrongValue[T](actual: T, expected: T): DummyError = dummyError
+    }
+
   implicit final lazy val dummyErrorIsFromThrowable: ErrorFromThrowable[DummyError] = (_: Throwable) => dummyError
 
 }

--- a/shared/src/main/scala/urldsl/errors/FragmentMatchingError.scala
+++ b/shared/src/main/scala/urldsl/errors/FragmentMatchingError.scala
@@ -5,6 +5,9 @@ trait FragmentMatchingError[E] {
   /** Happens when the fragment was expected but is missing. */
   def missingFragmentError: E
 
+  /** Happens when you don't want the fragment to be present, but it was there. */
+  def fragmentWasPresent(value: String): E
+
   /** Happens when the fragment is present but does not match the expected value. */
   def wrongValue[T](actual: T, expected: T): E
 }

--- a/shared/src/main/scala/urldsl/errors/FragmentMatchingError.scala
+++ b/shared/src/main/scala/urldsl/errors/FragmentMatchingError.scala
@@ -1,0 +1,10 @@
+package urldsl.errors
+
+trait FragmentMatchingError[E] {
+
+  /** Happens when the fragment was expected but is missing. */
+  def missingFragmentError: E
+
+  /** Happens when the fragment is present but does not match the expected value. */
+  def wrongValue[T](actual: T, expected: T): E
+}

--- a/shared/src/main/scala/urldsl/errors/PathMatchingError.scala
+++ b/shared/src/main/scala/urldsl/errors/PathMatchingError.scala
@@ -11,7 +11,7 @@ import urldsl.vocabulary.Segment
   *
   * @tparam A type of the error.
   */
-trait PathMatchingError[A] {
+trait PathMatchingError[+A] {
 
   def malformed(str: String): A
   def endOfSegmentRequired(remainingSegments: List[Segment]): A

--- a/shared/src/main/scala/urldsl/errors/SimpleFragmentMatchingError.scala
+++ b/shared/src/main/scala/urldsl/errors/SimpleFragmentMatchingError.scala
@@ -1,0 +1,19 @@
+package urldsl.errors
+
+sealed trait SimpleFragmentMatchingError
+
+object SimpleFragmentMatchingError {
+  case object MissingFragmentError extends SimpleFragmentMatchingError
+  case class WrongValue[T](actual: T, expected: T) extends SimpleFragmentMatchingError
+  case class FromThrowable(throwable: Throwable) extends SimpleFragmentMatchingError
+
+  implicit val errorFromThrowable: ErrorFromThrowable[SimpleFragmentMatchingError] = (throwable: Throwable) =>
+    FromThrowable(throwable)
+
+  implicit val itIsFragmentMatchingError: FragmentMatchingError[SimpleFragmentMatchingError] =
+    new FragmentMatchingError[SimpleFragmentMatchingError] {
+      def missingFragmentError: SimpleFragmentMatchingError = MissingFragmentError
+
+      def wrongValue[T](actual: T, expected: T): SimpleFragmentMatchingError = WrongValue(actual, expected)
+    }
+}

--- a/shared/src/main/scala/urldsl/errors/SimpleFragmentMatchingError.scala
+++ b/shared/src/main/scala/urldsl/errors/SimpleFragmentMatchingError.scala
@@ -6,6 +6,7 @@ object SimpleFragmentMatchingError {
   case object MissingFragmentError extends SimpleFragmentMatchingError
   case class WrongValue[T](actual: T, expected: T) extends SimpleFragmentMatchingError
   case class FromThrowable(throwable: Throwable) extends SimpleFragmentMatchingError
+  case class FragmentWasPresent(value: String) extends SimpleFragmentMatchingError
 
   implicit val errorFromThrowable: ErrorFromThrowable[SimpleFragmentMatchingError] = (throwable: Throwable) =>
     FromThrowable(throwable)
@@ -13,7 +14,7 @@ object SimpleFragmentMatchingError {
   implicit val itIsFragmentMatchingError: FragmentMatchingError[SimpleFragmentMatchingError] =
     new FragmentMatchingError[SimpleFragmentMatchingError] {
       def missingFragmentError: SimpleFragmentMatchingError = MissingFragmentError
-
       def wrongValue[T](actual: T, expected: T): SimpleFragmentMatchingError = WrongValue(actual, expected)
+      def fragmentWasPresent(value: String): SimpleFragmentMatchingError = FragmentWasPresent(value)
     }
 }

--- a/shared/src/main/scala/urldsl/language/AllImpl.scala
+++ b/shared/src/main/scala/urldsl/language/AllImpl.scala
@@ -1,0 +1,21 @@
+package urldsl.language
+
+import urldsl.errors.{FragmentMatchingError, ParamMatchingError, PathMatchingError}
+
+final class AllImpl[P, Q, F] private (
+    implicit
+    protected val pathError: PathMatchingError[P],
+    protected val queryError: ParamMatchingError[Q],
+    protected val fragmentError: FragmentMatchingError[F]
+) extends PathSegmentImpl[P]
+    with QueryParametersImpl[Q]
+    with FragmentImpl[F]
+
+object AllImpl {
+  def apply[P, Q, F](
+      implicit
+      pathError: PathMatchingError[P],
+      queryError: ParamMatchingError[Q],
+      fragmentError: FragmentMatchingError[F]
+  ): AllImpl[P, Q, F] = new AllImpl
+}

--- a/shared/src/main/scala/urldsl/language/Fragment.scala
+++ b/shared/src/main/scala/urldsl/language/Fragment.scala
@@ -164,17 +164,17 @@ object Fragment {
       printer: Printer[T],
       fragmentMatchingError: FragmentMatchingError[A],
       classTag: ClassTag[T]
-  ): Fragment[T, A] = factory[T, A](
+  ): Fragment[Unit, A] = factory[Unit, A](
     {
       case MaybeFragment(None) => Left(fragmentMatchingError.missingFragmentError)
       case MaybeFragment(Some(fragment)) =>
         fromString(fragment) match {
           case Left(value)  => Left(value)
-          case Right(t: T)  => Right(t)
+          case Right(_: T)  => Right(())
           case Right(value) => Left(fragmentMatchingError.wrongValue(value, t))
         }
     },
-    (printer.apply _).andThen(Some(_)).andThen(MaybeFragment)
+    _ => MaybeFragment(Some(printer.print(t)))
   )
 
   lazy val dummyErrorImpl: FragmentImpl[DummyError] = FragmentImpl[DummyError]

--- a/shared/src/main/scala/urldsl/language/Fragment.scala
+++ b/shared/src/main/scala/urldsl/language/Fragment.scala
@@ -33,7 +33,7 @@ trait Fragment[T, E] extends UrlPart[T, E] {
     */
   def createFragment(t: T): MaybeFragment
 
-  /** Creates the Fragment string contained in the given instance of T. */
+  /** Creates the Fragment string contained in the given instance of T. Automatically prepend # if non empty. */
   def fragmentString(t: T, encoder: UrlStringGenerator = UrlStringGenerator.default): String =
     encoder.makeFragment(createFragment(t))
 

--- a/shared/src/main/scala/urldsl/language/Fragment.scala
+++ b/shared/src/main/scala/urldsl/language/Fragment.scala
@@ -1,6 +1,10 @@
 package urldsl.language
 
-import urldsl.vocabulary.{Codec, MaybeFragment}
+import urldsl.errors.FragmentMatchingError
+import urldsl.url.UrlStringGenerator
+import urldsl.vocabulary.{Codec, FromString, MaybeFragment, Printer}
+
+import scala.language.implicitConversions
 
 /**
   * Represents the fragment (or ref) of an URL, containing an information of type T, or an error of type E.
@@ -25,12 +29,33 @@ trait Fragment[T, E] {
     */
   def createFragment(t: T): MaybeFragment
 
+  def fragmentString(t: T, encoder: UrlStringGenerator = UrlStringGenerator.default): String =
+    encoder.makeFragment(createFragment(t))
+
+  def fragmentString()(implicit ev: Unit =:= T): String = fragmentString(())
+
   def as[U](tToU: T => U, uToT: U => T): Fragment[U, E] = factory(
     fragment => matchFragment(fragment).map(tToU),
     (u: U) => createFragment(uToT(u))
   )
 
-  def as[U](implicit codec: Codec[T, U]): Fragment[U, E] = as[U](codec.leftToRight, codec.rightToLeft)
+  def as[U](implicit codec: Codec[T, U]): Fragment[U, E] = as[U](codec.leftToRight _, codec.rightToLeft _)
+
+  /**
+    * Turns this fragment matching a `T` into a fragment matching an [[Option]] of T.
+    * It will return Some(t) if t could be extracted, and None otherwise.
+    *
+    * The failure that happened and led to an error does not matter: it will result in None, no matter what.
+    */
+  def ? : Fragment[Option[T], E] = factory(
+    matchFragment(_) match {
+      case Left(_)      => Right(None)
+      case Right(value) => Right(Some(value))
+    }, {
+      case Some(t) => createFragment(t)
+      case None    => MaybeFragment(None)
+    }
+  )
 
 }
 
@@ -39,8 +64,60 @@ object Fragment {
   def factory[T, E](extractor: MaybeFragment => Either[E, T], generator: T => MaybeFragment): Fragment[T, E] =
     new Fragment[T, E] {
       def matchFragment(maybeFragment: MaybeFragment): Either[E, T] = extractor(maybeFragment)
-
       def createFragment(t: T): MaybeFragment = generator(t)
     }
+
+  /**
+    * Creates a fragment matching any element of type `T`, as long as the [[urldsl.vocabulary.FromString]] can
+    * de-serialize it.
+    *
+    * If the fragment is missing, returns an error.
+    */
+  def fragment[T, A](
+      implicit fromString: FromString[T, A],
+      printer: Printer[T],
+      fragmentMatchingError: FragmentMatchingError[A]
+  ): Fragment[T, A] = factory[T, A](
+    {
+      case MaybeFragment(None)           => Left(fragmentMatchingError.missingFragmentError)
+      case MaybeFragment(Some(fragment)) => fromString(fragment)
+    },
+    (printer.apply _).andThen(Some(_)).andThen(MaybeFragment)
+  )
+
+  /**
+    * Creates a fragment matching any element of type `T`, as long as the [[urldsl.vocabulary.FromString]] can
+    * de-serialize it.
+    *
+    * If the fragment is missing, returns None.
+    */
+  final def maybeFragment[T, A](
+      implicit fromString: FromString[T, A],
+      printer: Printer[T],
+      fragmentMatchingError: FragmentMatchingError[A]
+  ): Fragment[Option[T], A] = factory[Option[T], A](
+    {
+      case MaybeFragment(None)           => Right(None)
+      case MaybeFragment(Some(fragment)) => fromString(fragment).map(Some(_))
+    },
+    (maybeT: Option[T]) => MaybeFragment(maybeT.map(printer.apply))
+  )
+
+  implicit def fragmentFromExactValue[T, A](t: T)(
+      implicit fromString: FromString[T, A],
+      printer: Printer[T],
+      fragmentMatchingError: FragmentMatchingError[A]
+  ): Fragment[T, A] = factory[T, A](
+    {
+      case MaybeFragment(None) => Left(fragmentMatchingError.missingFragmentError)
+      case MaybeFragment(Some(fragment)) =>
+        fromString(fragment) match {
+          case Left(value)  => Left(value)
+          case Right(t)     => Right(t)
+          case Right(value) => Left(fragmentMatchingError.wrongValue(value, t))
+        }
+    },
+    (printer.apply _).andThen(Some(_)).andThen(MaybeFragment)
+  )
 
 }

--- a/shared/src/main/scala/urldsl/language/Fragment.scala
+++ b/shared/src/main/scala/urldsl/language/Fragment.scala
@@ -1,0 +1,46 @@
+package urldsl.language
+
+import urldsl.vocabulary.{Codec, MaybeFragment}
+
+/**
+  * Represents the fragment (or ref) of an URL, containing an information of type T, or an error of type E.
+  *
+  * @tparam T type represented by this PathSegment
+  * @tparam E type of the error that this PathSegment produces on "illegal" url paths.
+  */
+trait Fragment[T, E] {
+
+  import Fragment.factory
+
+  /**
+    * Extract the information contained in this fragment, as an instance of T.
+    *
+    * @param maybeFragment raw fragment information from the URL
+    * @return Right a T when the extraction was successful, and Left an error otherwise.
+    */
+  def matchFragment(maybeFragment: MaybeFragment): Either[E, T]
+
+  /**
+    * Creates a fragment information from an instance of T.
+    */
+  def createFragment(t: T): MaybeFragment
+
+  def as[U](tToU: T => U, uToT: U => T): Fragment[U, E] = factory(
+    fragment => matchFragment(fragment).map(tToU),
+    (u: U) => createFragment(uToT(u))
+  )
+
+  def as[U](implicit codec: Codec[T, U]): Fragment[U, E] = as[U](codec.leftToRight, codec.rightToLeft)
+
+}
+
+object Fragment {
+
+  def factory[T, E](extractor: MaybeFragment => Either[E, T], generator: T => MaybeFragment): Fragment[T, E] =
+    new Fragment[T, E] {
+      def matchFragment(maybeFragment: MaybeFragment): Either[E, T] = extractor(maybeFragment)
+
+      def createFragment(t: T): MaybeFragment = generator(t)
+    }
+
+}

--- a/shared/src/main/scala/urldsl/language/FragmentImpl.scala
+++ b/shared/src/main/scala/urldsl/language/FragmentImpl.scala
@@ -1,0 +1,36 @@
+package urldsl.language
+
+import urldsl.errors.FragmentMatchingError
+import urldsl.vocabulary.{FromString, Printer}
+
+import scala.reflect.ClassTag
+
+/**
+  * This is the analogue of [[PathSegmentImpl]] for the [[Fragment]] trait. It "pre-applies" the error type based on the
+  * provided [[FragmentMatchingError]].
+  *
+  * @param error implementation of [[FragmentMatchingError]] for generating relevant matching errors.
+  * @tparam E type of the "pre-applied" errors
+  */
+final class FragmentImpl[E](implicit error: FragmentMatchingError[E]) {
+
+  def fragment[T](implicit fromString: FromString[T, E], printer: Printer[T]): Fragment[T, E] = Fragment.fragment[T, E]
+
+  def maybeFragment[T](implicit fromString: FromString[T, E], printer: Printer[T]): Fragment[Option[T], E] =
+    Fragment.maybeFragment[T, E]
+
+  def emptyFragment: Fragment[Unit, E] = Fragment.empty
+
+  def asFragment[T](t: T)(
+      implicit fromString: FromString[T, E],
+      printer: Printer[T],
+      classTag: ClassTag[T]
+  ): Fragment[T, E] = t
+
+}
+
+object FragmentImpl {
+
+  /** Summoner for a [[FragmentImpl]] instance, given the [[FragmentMatchingError]] error. */
+  def apply[E](implicit error: FragmentMatchingError[E]): FragmentImpl[E] = new FragmentImpl[E]
+}

--- a/shared/src/main/scala/urldsl/language/FragmentImpl.scala
+++ b/shared/src/main/scala/urldsl/language/FragmentImpl.scala
@@ -9,19 +9,22 @@ import scala.reflect.ClassTag
   * This is the analogue of [[PathSegmentImpl]] for the [[Fragment]] trait. It "pre-applies" the error type based on the
   * provided [[FragmentMatchingError]].
   *
-  * @param error implementation of [[FragmentMatchingError]] for generating relevant matching errors.
   * @tparam E type of the "pre-applied" errors
   */
-final class FragmentImpl[E](implicit error: FragmentMatchingError[E]) {
+trait FragmentImpl[E] {
 
-  def fragment[T](implicit fromString: FromString[T, E], printer: Printer[T]): Fragment[T, E] = Fragment.fragment[T, E]
+  /** implementation of [[FragmentMatchingError]] for generating relevant matching errors. */
+  implicit protected val fragmentError: FragmentMatchingError[E]
 
-  def maybeFragment[T](implicit fromString: FromString[T, E], printer: Printer[T]): Fragment[Option[T], E] =
+  final def fragment[T](implicit fromString: FromString[T, E], printer: Printer[T]): Fragment[T, E] =
+    Fragment.fragment[T, E]
+
+  final def maybeFragment[T](implicit fromString: FromString[T, E], printer: Printer[T]): Fragment[Option[T], E] =
     Fragment.maybeFragment[T, E]
 
-  def emptyFragment: Fragment[Unit, E] = Fragment.empty
+  final def emptyFragment: Fragment[Unit, E] = Fragment.empty
 
-  def asFragment[T](t: T)(
+  final def asFragment[T](t: T)(
       implicit fromString: FromString[T, E],
       printer: Printer[T],
       classTag: ClassTag[T]
@@ -32,5 +35,7 @@ final class FragmentImpl[E](implicit error: FragmentMatchingError[E]) {
 object FragmentImpl {
 
   /** Summoner for a [[FragmentImpl]] instance, given the [[FragmentMatchingError]] error. */
-  def apply[E](implicit error: FragmentMatchingError[E]): FragmentImpl[E] = new FragmentImpl[E]
+  def apply[E](implicit error: FragmentMatchingError[E]): FragmentImpl[E] = new FragmentImpl[E] {
+    implicit protected val fragmentError: FragmentMatchingError[E] = error
+  }
 }

--- a/shared/src/main/scala/urldsl/language/FragmentImpl.scala
+++ b/shared/src/main/scala/urldsl/language/FragmentImpl.scala
@@ -4,6 +4,7 @@ import urldsl.errors.FragmentMatchingError
 import urldsl.vocabulary.{FromString, Printer}
 
 import scala.reflect.ClassTag
+import scala.language.implicitConversions
 
 /**
   * This is the analogue of [[PathSegmentImpl]] for the [[Fragment]] trait. It "pre-applies" the error type based on the
@@ -16,19 +17,32 @@ trait FragmentImpl[E] {
   /** implementation of [[FragmentMatchingError]] for generating relevant matching errors. */
   implicit protected val fragmentError: FragmentMatchingError[E]
 
+  /**
+    * Returns a [[Fragment]] matching an element of type T.
+    * If the fragment is missing, it fails with a missing fragment error.
+    */
   final def fragment[T](implicit fromString: FromString[T, E], printer: Printer[T]): Fragment[T, E] =
     Fragment.fragment[T, E]
 
+  /**
+    * Returns a [[Fragment]] matching an element of type T.
+    * If the fragment is missing, it succeeds with None.
+    */
   final def maybeFragment[T](implicit fromString: FromString[T, E], printer: Printer[T]): Fragment[Option[T], E] =
     Fragment.maybeFragment[T, E]
 
+  /**
+    * Returns a [[Fragment]] imposing that the URL does not contain any fragment.
+    *
+    * Note that a URL ending with "#" is considered having no fragment.
+    */
   final def emptyFragment: Fragment[Unit, E] = Fragment.empty
 
-  final def asFragment[T](t: T)(
+  implicit final def asFragment[T](t: T)(
       implicit fromString: FromString[T, E],
       printer: Printer[T],
       classTag: ClassTag[T]
-  ): Fragment[T, E] = t
+  ): Fragment[Unit, E] = Fragment.asFragment(t)
 
 }
 

--- a/shared/src/main/scala/urldsl/language/PathQueryFragmentRepr.scala
+++ b/shared/src/main/scala/urldsl/language/PathQueryFragmentRepr.scala
@@ -11,7 +11,7 @@ import urldsl.vocabulary.{
   Segment
 }
 
-final class PathQueryFragmentRepr[PathType, +PathError, ParamsType, ParamsError, FragmentType, FragmentError] private[language] (
+final class PathQueryFragmentRepr[PathType, +PathError, ParamsType, +ParamsError, FragmentType, +FragmentError] private[language] (
     pathSegment: PathSegment[PathType, PathError],
     queryParams: QueryParameters[ParamsType, ParamsError],
     fragment: Fragment[FragmentType, FragmentError]

--- a/shared/src/main/scala/urldsl/language/PathQueryFragmentRepr.scala
+++ b/shared/src/main/scala/urldsl/language/PathQueryFragmentRepr.scala
@@ -30,7 +30,7 @@ final class PathQueryFragmentRepr[PathType, +PathError, ParamsType, +ParamsError
   // note: should this rather be some kind of Validated instead of either?
   private[language] def matchUrl(path: List[Segment], params: Map[String, Param], maybeFragment: MaybeFragment): Either[
     PathQueryFragmentError[PathError, ParamsError, FragmentError],
-    PathQueryFragmentMatching[PathType, ParamsType, FragmentType]
+    PathQueryFragmentMatching[PathMatchOutput[PathType], ParamMatchOutput[ParamsType], FragmentType]
   ] =
     for {
       path <- pathSegment
@@ -55,14 +55,14 @@ final class PathQueryFragmentRepr[PathType, +PathError, ParamsType, +ParamsError
     FragmentType
   ]] = {
     val parser = urlStringParserGenerator.parser(url)
-    matchUrl(parser.segments, parser.params, parser.maybeFragmentObj)
+    matchUrl(parser.segments, parser.params, parser.maybeFragmentObj).map(_.extractInfo)
   }
 
   def createPart(
       info: PathQueryFragmentMatching[PathType, ParamsType, FragmentType],
       encoder: UrlStringGenerator
   ): String = {
-    val PathQueryFragmentMatching(PathMatchOutput(path, _), ParamMatchOutput(query, _), fragmentInfo) = info
+    val PathQueryFragmentMatching(path, query, fragmentInfo) = info
 
     val queryPart = queryParams.createPart(query, encoder) match {
       case ""    => ""

--- a/shared/src/main/scala/urldsl/language/PathQueryFragmentRepr.scala
+++ b/shared/src/main/scala/urldsl/language/PathQueryFragmentRepr.scala
@@ -1,0 +1,75 @@
+package urldsl.language
+
+import urldsl.url.{UrlStringGenerator, UrlStringParserGenerator}
+import urldsl.vocabulary.{
+  MaybeFragment,
+  Param,
+  ParamMatchOutput,
+  PathMatchOutput,
+  PathQueryFragmentError,
+  PathQueryFragmentMatching,
+  Segment
+}
+
+final class PathQueryFragmentRepr[PathType, +PathError, ParamsType, ParamsError, FragmentType, FragmentError] private[language] (
+    pathSegment: PathSegment[PathType, PathError],
+    queryParams: QueryParameters[ParamsType, ParamsError],
+    fragment: Fragment[FragmentType, FragmentError]
+) extends UrlPart[
+      PathQueryFragmentMatching[PathType, ParamsType, FragmentType],
+      PathQueryFragmentError[PathError, ParamsError, FragmentError]
+    ] {
+
+  private implicit class ErrorMappingEither[E, A](either: Either[E, A]) {
+    def mapError[F](f: E => F): Either[F, A] = either match {
+      case Left(value)  => Left(f(value))
+      case Right(value) => Right(value)
+    }
+  }
+
+  // note: should this rather be some kind of Validated instead of either?
+  private[language] def matchUrl(path: List[Segment], params: Map[String, Param], maybeFragment: MaybeFragment): Either[
+    PathQueryFragmentError[PathError, ParamsError, FragmentError],
+    PathQueryFragmentMatching[PathType, ParamsType, FragmentType]
+  ] =
+    for {
+      path <- pathSegment
+        .matchSegments(path)
+        .mapError[PathQueryFragmentError[PathError, ParamsError, FragmentError]](PathQueryFragmentError.PathError(_))
+      query <- queryParams
+        .matchParams(params)
+        .mapError[PathQueryFragmentError[PathError, ParamsError, FragmentError]](PathQueryFragmentError.ParamsError(_))
+      fragment <- fragment
+        .matchFragment(maybeFragment)
+        .mapError[PathQueryFragmentError[PathError, ParamsError, FragmentError]](
+          PathQueryFragmentError.FragmentError(_)
+        )
+    } yield PathQueryFragmentMatching(path, query, fragment)
+
+  def matchRawUrl(
+      url: String,
+      urlStringParserGenerator: UrlStringParserGenerator = UrlStringParserGenerator.defaultUrlStringParserGenerator
+  ): Either[PathQueryFragmentError[PathError, ParamsError, FragmentError], PathQueryFragmentMatching[
+    PathType,
+    ParamsType,
+    FragmentType
+  ]] = {
+    val parser = urlStringParserGenerator.parser(url)
+    matchUrl(parser.segments, parser.params, parser.maybeFragmentObj)
+  }
+
+  def createPart(
+      info: PathQueryFragmentMatching[PathType, ParamsType, FragmentType],
+      encoder: UrlStringGenerator
+  ): String = {
+    val PathQueryFragmentMatching(PathMatchOutput(path, _), ParamMatchOutput(query, _), fragmentInfo) = info
+
+    val queryPart = queryParams.createPart(query, encoder) match {
+      case ""    => ""
+      case other => "?" ++ other
+    }
+
+    pathSegment.createPart(path, encoder) ++ queryPart ++ fragment.createPart(fragmentInfo, encoder)
+  }
+
+}

--- a/shared/src/main/scala/urldsl/language/PathQueryFragmentRepr.scala
+++ b/shared/src/main/scala/urldsl/language/PathQueryFragmentRepr.scala
@@ -72,4 +72,34 @@ final class PathQueryFragmentRepr[PathType, +PathError, ParamsType, +ParamsError
     pathSegment.createPart(path, encoder) ++ queryPart ++ fragment.createPart(fragmentInfo, encoder)
   }
 
+  /** If this instance actually only bear path information, retrieves that information only. */
+  def pathOnly(
+      implicit ev1: Unit =:= ParamsType,
+      ev2: Unit =:= FragmentType
+  ): UrlPart[PathType, PathQueryFragmentError[PathError, ParamsError, FragmentError]] =
+    UrlPart.factory(
+      (str, urlParserGenerator) => matchRawUrl(str, urlParserGenerator).map(_.path),
+      (p, encoder) => createPart(PathQueryFragmentMatching(p, ev1(()), ev2(())), encoder)
+    )
+
+  /** If this instance actually only bear query information, retrieves that information only. */
+  def queryOnly(
+      implicit ev1: Unit =:= PathType,
+      ev2: Unit =:= FragmentType
+  ): UrlPart[ParamsType, PathQueryFragmentError[PathError, ParamsError, FragmentError]] =
+    UrlPart.factory(
+      (str, urlParserGenerator) => matchRawUrl(str, urlParserGenerator).map(_.query),
+      (q, encoder) => createPart(PathQueryFragmentMatching(ev1(()), q, ev2(())), encoder)
+    )
+
+  /** If this instance actually only bear fragment information, retrieves that information only. */
+  def fragmentOnly(
+      implicit ev1: Unit =:= ParamsType,
+      ev2: Unit =:= PathType
+  ): UrlPart[FragmentType, PathQueryFragmentError[PathError, ParamsError, FragmentError]] =
+    UrlPart.factory(
+      (str, urlParserGenerator) => matchRawUrl(str, urlParserGenerator).map(_.fragment),
+      (f, encoder) => createPart(PathQueryFragmentMatching(ev2(()), ev1(()), f), encoder)
+    )
+
 }

--- a/shared/src/main/scala/urldsl/language/PathSegment.scala
+++ b/shared/src/main/scala/urldsl/language/PathSegment.scala
@@ -166,6 +166,15 @@ trait PathSegment[T, +A] extends UrlPart[T, A] {
   )
 
   /**
+    * Matches using this [[PathSegment]], and then forgets its content.
+    * Uses the `default` value when creating the path to go back.
+    */
+  final def ignore(default: => T): PathSegment[Unit, A] = PathSegment.factory[Unit, A](
+    matchSegments(_).map(_.map(_ => ())),
+    (_: Unit) => createSegments(default)
+  )
+
+  /**
     * Forgets the information contained in the path parameter by injecting one.
     * This turn this "dynamic" [[PathSegment]] into a fix one.
     */

--- a/shared/src/main/scala/urldsl/language/PathSegment.scala
+++ b/shared/src/main/scala/urldsl/language/PathSegment.scala
@@ -207,9 +207,9 @@ object PathSegment {
   }
 
   /** Simple path segment that matches everything by passing segments down the line. */
-  final def empty[A]: PathSegment[Unit, A] =
-    factory[Unit, A](segments => Right(PathMatchOutput((), segments)), _ => Nil)
-  final def root[A]: PathSegment[Unit, A] = empty
+  final def empty: PathSegment[Unit, Nothing] =
+    factory[Unit, Nothing](segments => Right(PathMatchOutput((), segments)), _ => Nil)
+  final def root: PathSegment[Unit, Nothing] = empty
 
   /** Simple path segment that matches nothing. This is the neutral of the || operator. */
   final def noMatch[A](implicit pathMatchingError: PathMatchingError[A]): PathSegment[Unit, A] =

--- a/shared/src/main/scala/urldsl/language/PathSegment.scala
+++ b/shared/src/main/scala/urldsl/language/PathSegment.scala
@@ -1,7 +1,7 @@
 package urldsl.language
 
 import urldsl.errors.{DummyError, ErrorFromThrowable, PathMatchingError, SimplePathMatchingError}
-import urldsl.url.{UrlStringDecoder, UrlStringGenerator, UrlStringParser, UrlStringParserGenerator}
+import urldsl.url.{UrlStringDecoder, UrlStringGenerator, UrlStringParserGenerator}
 import urldsl.vocabulary._
 
 import scala.language.implicitConversions
@@ -11,7 +11,7 @@ import scala.language.implicitConversions
   * @tparam T type represented by this PathSegment
   * @tparam A type of the error that this PathSegment produces on "illegal" url paths.
   */
-trait PathSegment[T, A] {
+trait PathSegment[T, A] extends UrlPart[T, A] {
 
   /**
     * Tries to match the list of [[urldsl.vocabulary.Segment]]s to create an instance of `T`.
@@ -80,6 +80,8 @@ trait PathSegment[T, A] {
     createPath(())
   final def createPath(encoder: UrlStringGenerator)(implicit ev: Unit =:= T): String =
     createPath((), encoder)
+
+  final def createPart(t: T, encoder: UrlStringGenerator): String = createPath(t, encoder)
 
   /**
     * Concatenates `this` [[urldsl.language.PathSegment]] with `that` one, "tupling" the types with the [[Tupler]]

--- a/shared/src/main/scala/urldsl/language/PathSegment.scala
+++ b/shared/src/main/scala/urldsl/language/PathSegment.scala
@@ -192,8 +192,17 @@ trait PathSegment[T, +A] extends UrlPart[T, A] {
       (_: Unit) => createSegments(t)
     )
 
-//  final def withFragment[FragmentType, FragmentError](fragment: Fragment[FragmentType, FragmentError]) =
-//    new PathQueryFragmentRepr(this, QueryParameters.empty[Unit, Nothing])
+  /**
+    * Associates this [[PathSegment]] with the given [[Fragment]] in order to match raw urls satisfying both
+    * conditions, and returning the outputs from both.
+    *
+    * The query part of the url will be *ignored* (and will return Unit).
+    */
+  final def withFragment[FragmentType, FragmentError](
+      fragment: Fragment[FragmentType, FragmentError]
+  ): PathQueryFragmentRepr[T, A, Unit, Nothing, FragmentType, FragmentError] =
+    new PathQueryFragmentRepr(this, QueryParameters.ignore, fragment)
+
 }
 
 object PathSegment {

--- a/shared/src/main/scala/urldsl/language/PathSegmentImpl.scala
+++ b/shared/src/main/scala/urldsl/language/PathSegmentImpl.scala
@@ -11,12 +11,14 @@ import urldsl.vocabulary.{FromString, Printer}
   * conveniently invoked using the `segment` method below.
   *
   * @example
+  *   {{{
   *          val pathSegmentImpl = PathSegmentImpl[DummyError]
   *          import pathSegmentImpl._
   *
   *          root / "hello"  // this is of type PathSegment[Unit, DummyError] thanks to the import above.
   *           (note that in this case there is already a PathSegmentImpl for [[urldsl.errors.DummyError]] in the
   *           [[PathSegment]] companion object)
+  *   }}}
   *
   * @param error implementation of [[urldsl.errors.PathMatchingError]] for type A.
   * @tparam A type of error.

--- a/shared/src/main/scala/urldsl/language/PathSegmentWithQueryParams.scala
+++ b/shared/src/main/scala/urldsl/language/PathSegmentWithQueryParams.scala
@@ -3,7 +3,7 @@ package urldsl.language
 import urldsl.url.{UrlStringDecoder, UrlStringGenerator, UrlStringParserGenerator}
 import urldsl.vocabulary._
 
-final class PathSegmentWithQueryParams[PathType, +PathError, ParamsType, ParamsError] private[language] (
+final class PathSegmentWithQueryParams[PathType, +PathError, ParamsType, +ParamsError] private[language] (
     pathSegment: PathSegment[PathType, PathError],
     queryParams: QueryParameters[ParamsType, ParamsError]
 ) extends UrlPart[UrlMatching[PathType, ParamsType], Either[PathError, ParamsError]] {
@@ -72,14 +72,14 @@ final class PathSegmentWithQueryParams[PathType, +PathError, ParamsType, ParamsE
   ): String =
     pathSegment.createPath(path, generator) ++ "?" ++ queryParams.createParamsString(params, generator)
 
-  def &[OtherParamsType](otherParams: QueryParameters[OtherParamsType, ParamsError])(
+  def &[OtherParamsType, ParamsError1 >: ParamsError](otherParams: QueryParameters[OtherParamsType, ParamsError1])(
       implicit
       ev: Tupler[ParamsType, OtherParamsType]
-  ): PathSegmentWithQueryParams[PathType, PathError, ev.Out, ParamsError] =
-    new PathSegmentWithQueryParams[PathType, PathError, ev.Out, ParamsError](
+  ): PathSegmentWithQueryParams[PathType, PathError, ev.Out, ParamsError1] =
+    new PathSegmentWithQueryParams[PathType, PathError, ev.Out, ParamsError1](
       pathSegment,
       (queryParams & otherParams)
-        .asInstanceOf[QueryParameters[ev.Out, ParamsError]] // not necessary but IntelliJ complains.
+        .asInstanceOf[QueryParameters[ev.Out, ParamsError1]] // not necessary but IntelliJ complains.
     )
 
   def withFragment[FragmentType, FragmentError](

--- a/shared/src/main/scala/urldsl/language/PathSegmentWithQueryParams.scala
+++ b/shared/src/main/scala/urldsl/language/PathSegmentWithQueryParams.scala
@@ -6,7 +6,7 @@ import urldsl.vocabulary._
 final class PathSegmentWithQueryParams[PathType, PathError, ParamsType, ParamsError] private[language] (
     pathSegment: PathSegment[PathType, PathError],
     queryParams: QueryParameters[ParamsType, ParamsError]
-) {
+) extends UrlPart[UrlMatching[PathType, ParamsType], Either[PathError, ParamsError]] {
 
   def matchUrl(
       path: List[Segment],
@@ -82,4 +82,6 @@ final class PathSegmentWithQueryParams[PathType, PathError, ParamsType, ParamsEr
         .asInstanceOf[QueryParameters[ev.Out, ParamsError]] // not necessary but IntelliJ complains.
     )
 
+  def createPart(t: UrlMatching[PathType, ParamsType], encoder: UrlStringGenerator): String =
+    createUrlString(t.path, t.params, encoder)
 }

--- a/shared/src/main/scala/urldsl/language/PathSegmentWithQueryParams.scala
+++ b/shared/src/main/scala/urldsl/language/PathSegmentWithQueryParams.scala
@@ -3,7 +3,7 @@ package urldsl.language
 import urldsl.url.{UrlStringDecoder, UrlStringGenerator, UrlStringParserGenerator}
 import urldsl.vocabulary._
 
-final class PathSegmentWithQueryParams[PathType, PathError, ParamsType, ParamsError] private[language] (
+final class PathSegmentWithQueryParams[PathType, +PathError, ParamsType, ParamsError] private[language] (
     pathSegment: PathSegment[PathType, PathError],
     queryParams: QueryParameters[ParamsType, ParamsError]
 ) extends UrlPart[UrlMatching[PathType, ParamsType], Either[PathError, ParamsError]] {
@@ -81,6 +81,11 @@ final class PathSegmentWithQueryParams[PathType, PathError, ParamsType, ParamsEr
       (queryParams & otherParams)
         .asInstanceOf[QueryParameters[ev.Out, ParamsError]] // not necessary but IntelliJ complains.
     )
+
+  def withFragment[FragmentType, FragmentError](
+      fragment: Fragment[FragmentType, FragmentError]
+  ): PathQueryFragmentRepr[PathType, PathError, ParamsType, ParamsError, FragmentType, FragmentError] =
+    new PathQueryFragmentRepr(pathSegment, queryParams, fragment)
 
   def createPart(t: UrlMatching[PathType, ParamsType], encoder: UrlStringGenerator): String =
     createUrlString(t.path, t.params, encoder)

--- a/shared/src/main/scala/urldsl/language/PathSegmentWithQueryParams.scala
+++ b/shared/src/main/scala/urldsl/language/PathSegmentWithQueryParams.scala
@@ -70,7 +70,7 @@ final class PathSegmentWithQueryParams[PathType, PathError, ParamsType, ParamsEr
       params: ParamsType,
       generator: UrlStringGenerator = UrlStringGenerator.default
   ): String =
-    pathSegment.createPath(path, generator) + "?" + queryParams.createParamsString(params, generator)
+    pathSegment.createPath(path, generator) ++ "?" ++ queryParams.createParamsString(params, generator)
 
   def &[OtherParamsType](otherParams: QueryParameters[OtherParamsType, ParamsError])(
       implicit

--- a/shared/src/main/scala/urldsl/language/QueryParameters.scala
+++ b/shared/src/main/scala/urldsl/language/QueryParameters.scala
@@ -4,7 +4,7 @@ import urldsl.errors.{DummyError, ParamMatchingError, SimpleParamMatchingError}
 import urldsl.url.{UrlStringDecoder, UrlStringGenerator, UrlStringParserGenerator}
 import urldsl.vocabulary._
 
-trait QueryParameters[Q, A] {
+trait QueryParameters[Q, A] extends UrlPart[Q, A] {
 
   import QueryParameters._
 
@@ -54,6 +54,9 @@ trait QueryParameters[Q, A] {
     */
   final def createParamsString(q: Q, encoder: UrlStringGenerator = UrlStringGenerator.default): String =
     encoder.makeParams(createParams(q))
+
+  final def createPart(q: Q, encoder: UrlStringGenerator = UrlStringGenerator.default): String =
+    createParamsString(q, encoder)
 
   /**
     * Adds `that` QueryParameters to `this` one, "tupling" the returned type with the implicit [[urldsl.language.Tupler]]

--- a/shared/src/main/scala/urldsl/language/QueryParameters.scala
+++ b/shared/src/main/scala/urldsl/language/QueryParameters.scala
@@ -132,6 +132,17 @@ trait QueryParameters[Q, +A] extends UrlPart[Q, A] {
     (codec.rightToLeft _).andThen(createParams)
   )
 
+  /**
+    * Associates this [[QueryParameters]] with the given [[Fragment]] in order to match raw urls satisfying both
+    * conditions, and returning the outputs from both.
+    *
+    * The path part of the url will be *ignored* (and will return Unit).
+    */
+  final def withFragment[FragmentType, FragmentError](
+      fragment: Fragment[FragmentType, FragmentError]
+  ): PathQueryFragmentRepr[Unit, Nothing, Q, A, FragmentType, FragmentError] =
+    new PathQueryFragmentRepr(PathSegment.root, this, fragment)
+
 }
 
 object QueryParameters {

--- a/shared/src/main/scala/urldsl/language/QueryParameters.scala
+++ b/shared/src/main/scala/urldsl/language/QueryParameters.scala
@@ -144,7 +144,7 @@ object QueryParameters {
     def createParams(q: Q): Map[String, Param] = creating(q)
   }
 
-  final def empty[A](implicit paramMatchingError: ParamMatchingError[A]): QueryParameters[Unit, A] = factory[Unit, A](
+  final def empty: QueryParameters[Unit, Nothing] = factory[Unit, Nothing](
     (params: Map[String, Param]) => Right(ParamMatchOutput((), params)),
     _ => Map()
   )

--- a/shared/src/main/scala/urldsl/language/QueryParameters.scala
+++ b/shared/src/main/scala/urldsl/language/QueryParameters.scala
@@ -149,6 +149,9 @@ object QueryParameters {
     _ => Map()
   )
 
+  /** Alias for empty which seems to better reflect the semantic. */
+  final def ignore: QueryParameters[Unit, Nothing] = empty
+
   final def simpleQueryParam[Q, A](
       paramName: String,
       matching: Param => Either[A, Q],

--- a/shared/src/main/scala/urldsl/language/QueryParametersImpl.scala
+++ b/shared/src/main/scala/urldsl/language/QueryParametersImpl.scala
@@ -3,9 +3,11 @@ package urldsl.language
 import urldsl.errors.ParamMatchingError
 import urldsl.vocabulary.{FromString, Printer}
 
-final class QueryParametersImpl[A](implicit error: ParamMatchingError[A]) {
+trait QueryParametersImpl[A] {
 
-  val empty: QueryParameters[Unit, A] = QueryParameters.empty[A]
+  implicit protected val queryError: ParamMatchingError[A]
+
+  val empty: QueryParameters[Unit, A] = QueryParameters.empty
 
   def param[Q](paramName: String)(implicit fromString: FromString[Q, A], printer: Printer[Q]): QueryParameters[Q, A] =
     QueryParameters.param(paramName)
@@ -20,6 +22,8 @@ final class QueryParametersImpl[A](implicit error: ParamMatchingError[A]) {
 object QueryParametersImpl {
 
   /** Invoker */
-  def apply[A](implicit error: ParamMatchingError[A]): QueryParametersImpl[A] = new QueryParametersImpl[A]
+  def apply[A](implicit error: ParamMatchingError[A]): QueryParametersImpl[A] = new QueryParametersImpl[A] {
+    implicit protected val queryError: ParamMatchingError[A] = error
+  }
 
 }

--- a/shared/src/main/scala/urldsl/language/QueryParametersImpl.scala
+++ b/shared/src/main/scala/urldsl/language/QueryParametersImpl.scala
@@ -7,7 +7,13 @@ trait QueryParametersImpl[A] {
 
   implicit protected val queryError: ParamMatchingError[A]
 
+  @deprecated(
+    "empty was poorly named, and is replaced by `ignore`. The semantic for empty might change in the future!",
+    since = "0.3.0"
+  )
   val empty: QueryParameters[Unit, A] = QueryParameters.empty
+
+  val ignore: QueryParameters[Unit, A] = QueryParameters.ignore
 
   def param[Q](paramName: String)(implicit fromString: FromString[Q, A], printer: Printer[Q]): QueryParameters[Q, A] =
     QueryParameters.param(paramName)

--- a/shared/src/main/scala/urldsl/language/UrlPart.scala
+++ b/shared/src/main/scala/urldsl/language/UrlPart.scala
@@ -10,7 +10,7 @@ import urldsl.url.{UrlStringGenerator, UrlStringParserGenerator}
   * A [[UrlPart]] is also able to generate its corresponding part of the URL by ingesting an element of type T. When
   * doing that, it outputs a String (whose semantic may vary depending on the type of [[UrlPart]] you are dealing with).
   */
-trait UrlPart[T, E] {
+trait UrlPart[T, +E] {
 
   def matchRawUrl(
       url: String,

--- a/shared/src/main/scala/urldsl/language/UrlPart.scala
+++ b/shared/src/main/scala/urldsl/language/UrlPart.scala
@@ -1,0 +1,30 @@
+package urldsl.language
+
+import urldsl.url.{UrlStringGenerator, UrlStringParserGenerator}
+
+/**
+  * A [[UrlPart]] represents a part of (or the entire) URL and is able to extract some information out of it.
+  * When it succeeds to extract information, it returns an element of type T (wrapped in a [[Right]]). When it fails
+  * to extract such information, it returns an error type E (wrapped in a [[Left]].
+  *
+  * A [[UrlPart]] is also able to generate its corresponding part of the URL by ingesting an element of type T. When
+  * doing that, it outputs a String (whose semantic may vary depending on the type of [[UrlPart]] you are dealing with).
+  */
+trait UrlPart[T, E] {
+
+  def matchRawUrl(
+      url: String,
+      urlStringParserGenerator: UrlStringParserGenerator = UrlStringParserGenerator.defaultUrlStringParserGenerator
+  ): Either[E, T]
+
+  /** Takes an instance of T and generate the part of the URL contained in this T */
+  def createPart(t: T, encoder: UrlStringGenerator = UrlStringGenerator.default): String
+
+  /** Sugar when T =:= Unit */
+  final def createPart(encoder: UrlStringGenerator)(implicit ev: Unit =:= T): String =
+    createPart(ev(()), encoder)
+
+  /** Sugar when T =:= Unit */
+  final def createPart()(implicit ev: Unit =:= T): String = createPart(ev(()))
+
+}

--- a/shared/src/main/scala/urldsl/language/UrlPart.scala
+++ b/shared/src/main/scala/urldsl/language/UrlPart.scala
@@ -28,3 +28,24 @@ trait UrlPart[T, +E] {
   final def createPart()(implicit ev: Unit =:= T): String = createPart(ev(()))
 
 }
+
+object UrlPart {
+
+  private[language] def factory[T, E](
+      matcher: (String, UrlStringParserGenerator) => Either[E, T],
+      generator: (T, UrlStringGenerator) => String
+  ) = new UrlPart[T, E] {
+    def matchRawUrl(url: String, urlStringParserGenerator: UrlStringParserGenerator): Either[E, T] =
+      matcher(url, urlStringParserGenerator)
+
+    def createPart(t: T, encoder: UrlStringGenerator): String = generator(t, encoder)
+  }
+
+  /**
+    * Type alias when you don't care about what kind of error is issued.
+    * [[Any]] can seem weird, but it has to be understood as "since it can fail with anything, I won't be able to do
+    * anything with the error, which means that I can only check whether it failed or not".
+    */
+  type SimpleUrlPart[T] = UrlPart[T, Any]
+
+}

--- a/shared/src/main/scala/urldsl/language/package.scala
+++ b/shared/src/main/scala/urldsl/language/package.scala
@@ -1,0 +1,19 @@
+package urldsl
+
+import urldsl.errors.{
+  DummyError,
+  FragmentMatchingError,
+  ParamMatchingError,
+  PathMatchingError,
+  SimpleFragmentMatchingError,
+  SimpleParamMatchingError,
+  SimplePathMatchingError
+}
+
+package object language {
+
+  val dummyErrorImpl: AllImpl[DummyError, DummyError, DummyError] = AllImpl[DummyError, DummyError, DummyError]
+  val simpleErrorImpl: AllImpl[SimplePathMatchingError, SimpleParamMatchingError, SimpleFragmentMatchingError] =
+    AllImpl[SimplePathMatchingError, SimpleParamMatchingError, SimpleFragmentMatchingError]
+
+}

--- a/shared/src/main/scala/urldsl/url/UrlStringDecoder.scala
+++ b/shared/src/main/scala/urldsl/url/UrlStringDecoder.scala
@@ -12,4 +12,10 @@ trait UrlStringDecoder {
       .map { case (key, value) => key -> value.transform(decode(_)) }
 }
 
-object UrlStringDecoder extends DefaultUrlStringDecoder
+object UrlStringDecoder extends DefaultUrlStringDecoder {
+
+  val defaultDecoder: UrlStringDecoder = defaultDecoder0
+
+  val identityDecoder: UrlStringDecoder = (str: String, _: String) => str
+
+}

--- a/shared/src/main/scala/urldsl/url/UrlStringGenerator.scala
+++ b/shared/src/main/scala/urldsl/url/UrlStringGenerator.scala
@@ -32,4 +32,8 @@ trait UrlStringGenerator {
 
 }
 
-object UrlStringGenerator extends DefaultUrlStringGenerator
+object UrlStringGenerator extends DefaultUrlStringGenerator {
+
+  val default: UrlStringGenerator = default0
+
+}

--- a/shared/src/main/scala/urldsl/url/UrlStringGenerator.scala
+++ b/shared/src/main/scala/urldsl/url/UrlStringGenerator.scala
@@ -1,6 +1,6 @@
 package urldsl.url
 
-import urldsl.vocabulary.{Param, Segment}
+import urldsl.vocabulary.{MaybeFragment, Param, Segment}
 
 trait UrlStringGenerator {
 
@@ -9,11 +9,11 @@ trait UrlStringGenerator {
   def makePath(segments: List[Segment]): String =
     segments.map(_.content).map(encode(_)).filter(_.nonEmpty).mkString("/")
 
-  def makeParamsMap(params: Map[String, Param]): Map[String, List[String]] =
+  final def makeParamsMap(params: Map[String, Param]): Map[String, List[String]] =
     params
       .map { case (key, value) => key -> value.content.map(encode(_)) }
 
-  def makeParams(params: Map[String, Param]): String =
+  final def makeParams(params: Map[String, Param]): String =
     makeParamsMap(params)
       .flatMap { case (key, values) => values.map(value => s"$key=$value") }
       .mkString("&")
@@ -23,6 +23,11 @@ trait UrlStringGenerator {
     val pathString = makePath(segments)
 
     pathString + (if (paramsString.nonEmpty) "?" else "") + pathString
+  }
+
+  final def makeFragment(maybeFragment: MaybeFragment): String = maybeFragment.value match {
+    case Some(value) => "#" ++ value
+    case None        => ""
   }
 
 }

--- a/shared/src/main/scala/urldsl/url/UrlStringGenerator.scala
+++ b/shared/src/main/scala/urldsl/url/UrlStringGenerator.scala
@@ -26,7 +26,8 @@ trait UrlStringGenerator {
   }
 
   final def makeFragment(maybeFragment: MaybeFragment): String = maybeFragment.value match {
-    case Some(value) => "#" ++ value
+    case Some("")    => ""
+    case Some(value) => "#" ++ encode(value)
     case None        => ""
   }
 

--- a/shared/src/main/scala/urldsl/url/UrlStringParser.scala
+++ b/shared/src/main/scala/urldsl/url/UrlStringParser.scala
@@ -1,6 +1,6 @@
 package urldsl.url
 
-import urldsl.vocabulary.{Param, Segment}
+import urldsl.vocabulary.{MaybeFragment, Param, Segment}
 
 trait UrlStringParser extends UrlStringDecoder {
 
@@ -20,5 +20,6 @@ trait UrlStringParser extends UrlStringDecoder {
 
   final def segments: List[Segment] = decodePath(path)
   final def params: Map[String, Param] = decodeParams(queryParametersString)
+  final def maybeFragmentObj: MaybeFragment = MaybeFragment(maybeFragment)
 
 }

--- a/shared/src/main/scala/urldsl/url/UrlStringParser.scala
+++ b/shared/src/main/scala/urldsl/url/UrlStringParser.scala
@@ -6,8 +6,17 @@ trait UrlStringParser extends UrlStringDecoder {
 
   val rawUrl: String
 
+  /** Returns the raw content of the query string. */
   def queryParametersString: String
+
+  /** Returns the raw content of the path. */
   def path: String
+
+  /** Returns the raw content of the fragment (sometimes called ref), or None if there is no fragment */
+  def maybeFragment: Option[String]
+
+  /** Alias for [[maybeFragment]].  */
+  final def maybeRef: Option[String] = maybeFragment
 
   final def segments: List[Segment] = decodePath(path)
   final def params: Map[String, Param] = decodeParams(queryParametersString)

--- a/shared/src/main/scala/urldsl/url/UrlStringParserGenerator.scala
+++ b/shared/src/main/scala/urldsl/url/UrlStringParserGenerator.scala
@@ -6,4 +6,12 @@ trait UrlStringParserGenerator {
 
 }
 
-object UrlStringParserGenerator extends DefaultUrlParserGenerator
+object UrlStringParserGenerator extends DefaultUrlParserGenerator {
+
+  // The unnecessary trick below is used to make IntelliJ happier in the rest of the codebase.
+  // It ain't pretty, but does the trick.
+
+  /** Returns a default implementation of the [[UrlStringParserGenerator]] */
+  val defaultUrlStringParserGenerator: UrlStringParserGenerator = defaultUrlStringParserGenerator0
+
+}

--- a/shared/src/main/scala/urldsl/vocabulary/MaybeFragment.scala
+++ b/shared/src/main/scala/urldsl/vocabulary/MaybeFragment.scala
@@ -10,4 +10,6 @@ final case class MaybeFragment(value: Option[String]) extends AnyVal {
   /** Prepend the hashtag symbol if the fragment is present, otherwise returns the empty string. */
   def representation: String = value.map("#" ++ _).getOrElse("")
 
+  def isEmpty: Boolean = value.isEmpty
+
 }

--- a/shared/src/main/scala/urldsl/vocabulary/MaybeFragment.scala
+++ b/shared/src/main/scala/urldsl/vocabulary/MaybeFragment.scala
@@ -1,0 +1,13 @@
+package urldsl.vocabulary
+
+/**
+  * Wrapper around the raw fragment part of the URL.
+  *
+  * None when the URL does not contain any fragment.
+  */
+final case class MaybeFragment(value: Option[String]) extends AnyVal {
+
+  /** Prepend the hashtag symbol if the fragment is present, otherwise returns the empty string. */
+  def representation: String = value.map("#" ++ _).getOrElse("")
+
+}

--- a/shared/src/main/scala/urldsl/vocabulary/MaybeFragment.scala
+++ b/shared/src/main/scala/urldsl/vocabulary/MaybeFragment.scala
@@ -12,4 +12,6 @@ final case class MaybeFragment(value: Option[String]) extends AnyVal {
 
   def isEmpty: Boolean = value.isEmpty
 
+  def nonEmpty: Boolean = value.nonEmpty
+
 }

--- a/shared/src/main/scala/urldsl/vocabulary/Param.scala
+++ b/shared/src/main/scala/urldsl/vocabulary/Param.scala
@@ -1,6 +1,6 @@
 package urldsl.vocabulary
 
-final case class Param(content: List[String]) {
+final case class Param(content: List[String]) extends AnyVal {
   def transform(f: String => String): Param = Param(content.map(f))
 }
 

--- a/shared/src/main/scala/urldsl/vocabulary/PathQueryFragmentError.scala
+++ b/shared/src/main/scala/urldsl/vocabulary/PathQueryFragmentError.scala
@@ -1,0 +1,13 @@
+package urldsl.vocabulary
+
+import urldsl.errors.{FragmentMatchingError, ParamMatchingError, PathMatchingError}
+
+sealed trait PathQueryFragmentError[+P, +Q, +F]
+
+object PathQueryFragmentError {
+
+  case class PathError[A](error: A) extends PathQueryFragmentError[A, Nothing, Nothing]
+  case class ParamsError[A](error: A) extends PathQueryFragmentError[Nothing, A, Nothing]
+  case class FragmentError[A](error: A) extends PathQueryFragmentError[Nothing, Nothing, A]
+
+}

--- a/shared/src/main/scala/urldsl/vocabulary/PathQueryFragmentMatching.scala
+++ b/shared/src/main/scala/urldsl/vocabulary/PathQueryFragmentMatching.scala
@@ -1,3 +1,11 @@
 package urldsl.vocabulary
 
-final case class PathQueryFragmentMatching[P, Q, F](path: PathMatchOutput[P], query: ParamMatchOutput[Q], fragment: F)
+final case class PathQueryFragmentMatching[P, Q, F](path: P, query: Q, fragment: F) {
+
+  def extractInfo[P1, Q1](
+      implicit ev1: P =:= PathMatchOutput[P1],
+      ev2: Q =:= ParamMatchOutput[Q1]
+  ): PathQueryFragmentMatching[P1, Q1, F] =
+    PathQueryFragmentMatching(ev1(path).output, ev2(query).output, fragment)
+
+}

--- a/shared/src/main/scala/urldsl/vocabulary/PathQueryFragmentMatching.scala
+++ b/shared/src/main/scala/urldsl/vocabulary/PathQueryFragmentMatching.scala
@@ -1,0 +1,3 @@
+package urldsl.vocabulary
+
+final case class PathQueryFragmentMatching[P, Q, F](path: PathMatchOutput[P], query: ParamMatchOutput[Q], fragment: F)

--- a/shared/src/main/scala/urldsl/vocabulary/Segment.scala
+++ b/shared/src/main/scala/urldsl/vocabulary/Segment.scala
@@ -2,7 +2,7 @@ package urldsl.vocabulary
 
 import scala.language.implicitConversions
 
-final case class Segment(content: String) {
+final case class Segment(content: String) extends AnyVal {
   def map(f: String => String): Segment = Segment(f(content))
 }
 

--- a/shared/src/main/scala/urldsl/vocabulary/Segment.scala
+++ b/shared/src/main/scala/urldsl/vocabulary/Segment.scala
@@ -2,6 +2,7 @@ package urldsl.vocabulary
 
 import scala.language.implicitConversions
 
+/** A [[Segment]] is a simple wrapper around a specific String content between two `/`. */
 final case class Segment(content: String) extends AnyVal {
   def map(f: String => String): Segment = Segment(f(content))
 }

--- a/shared/src/test/scala/urldsl/examples/CombinedExamples.scala
+++ b/shared/src/test/scala/urldsl/examples/CombinedExamples.scala
@@ -1,0 +1,76 @@
+package urldsl.examples
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import urldsl.vocabulary.{PathQueryFragmentMatching, UrlMatching}
+
+/**
+  * In this class, we showcase examples of combining:
+  * - [[urldsl.language.PathSegment]]
+  * - [[urldsl.language.QueryParameters]], and
+  * - [[urldsl.language.Fragment]].
+  *
+  * Unlike other examples, we will use the [[urldsl.errors.DummyError]] implementations.
+  *
+  * When you combine these, you will end up manipulating objects that can seem nasty. However, the user experience
+  * of code that you actually have to write should stay pretty.
+  */
+//noinspection TypeAnnotation
+final class CombinedExamples extends AnyFlatSpec with Matchers {
+
+  import urldsl.language.dummyErrorImpl._
+
+  val pathPart = root / "foo" / segment[Int] / true
+  val queryPart = param[String]("bar") & listParam[Int]("other")
+  val fragmentPart = fragment[String]
+
+  "Some matching examples" should "work" in {
+
+    /** We can combine a [[urldsl.language.PathSegment]] and a [[urldsl.language.QueryParameters]] */
+    (pathPart ? queryPart)
+      .matchRawUrl(sampleUrl) should be(
+      Right(UrlMatching(23, ("stuff", List(2, 3))))
+    )
+
+    /** We can combine a [[urldsl.language.PathSegment]] and a [[urldsl.language.Fragment]] */
+    pathPart.withFragment(fragmentPart).matchRawUrl(sampleUrl) should be(
+      Right(PathQueryFragmentMatching(23, (), "the-ref"))
+    )
+
+    /** And we can of course combine a [[urldsl.language.QueryParameters]] and a [[urldsl.language.Fragment]] */
+    queryPart.withFragment(fragmentPart).matchRawUrl(sampleUrl) should be(
+      Right(PathQueryFragmentMatching((), ("stuff", List(2, 3)), "the-ref"))
+    )
+
+    /**
+      * Finally, we can combine everything.
+      * Note that we first have to combine a [[urldsl.language.PathSegment]] and the [[urldsl.language.QueryParameters]]
+      * and then add the [[urldsl.language.Fragment]].
+      */
+    (pathPart ? queryPart).withFragment(fragmentPart).matchRawUrl(sampleUrl) should be(
+      Right(PathQueryFragmentMatching(23, ("stuff", List(2, 3)), "the-ref"))
+    )
+
+  }
+
+  "This generating example" should "work" in {
+
+    pathPart.withFragment(fragmentPart).createPart(PathQueryFragmentMatching(23, (), "some-other-ref")) should be(
+      """foo/23/true#some-other-ref"""
+    )
+
+    queryPart
+      .withFragment(fragmentPart)
+      .createPart(PathQueryFragmentMatching((), ("stuff", List(2, 3)), "the-ref")) should be(
+      """?bar=stuff&other=2&other=3#the-ref"""
+    )
+
+    (pathPart ? queryPart)
+      .withFragment(fragmentPart)
+      .createPart(PathQueryFragmentMatching(23, ("stuff", List(2, 3)), "the-ref")) should be(
+      """foo/23/true?bar=stuff&other=2&other=3#the-ref"""
+    )
+
+  }
+
+}

--- a/shared/src/test/scala/urldsl/examples/FragmentExamples.scala
+++ b/shared/src/test/scala/urldsl/examples/FragmentExamples.scala
@@ -1,0 +1,55 @@
+package urldsl.examples
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import urldsl.errors.SimpleFragmentMatchingError
+import urldsl.language.Fragment
+
+/**
+  * This class exposes some example of usage of the [[urldsl.language.Fragment]] class.
+  *
+  * The `sampleUrl` and `sampleUrlWithoutFragment` used throughout this example class is defined in the
+  * [[urldsl.examples]] package object.
+  */
+final class FragmentExamples extends AnyFlatSpec with Matchers {
+
+  import urldsl.language.simpleErrorImpl._
+
+  "Some matching examples" should "work" in {
+
+    /**
+      * We can ask that the fragment should be some specific value.
+      * Note that unlike [[urldsl.language.PathSegment]], there is no "root" element and hence, we need to cast an
+      * element by hand into a [[urldsl.language.Fragment]]. There is still an implicit conversion, but it will be
+      * called only in a place where you ask for a [[urldsl.language.Fragment]] (see below)
+      */
+    asFragment("the-ref").matchRawUrl(sampleUrl) should be(Right(()))
+
+    /** We can also ask that the fragment is present and of the desired type. */
+    fragment[String].matchRawUrl(sampleUrl) should be(Right("the-ref"))
+
+    /**
+      * We can require that the fragment is not there (which would also be the case if the url ends with #!)
+      */
+    emptyFragment.matchRawUrl(sampleUrl) should be(Left(SimpleFragmentMatchingError.FragmentWasPresent("the-ref")))
+    emptyFragment.matchRawUrl(sampleUrlWithoutFragment) should be(Right(()))
+
+    /** We can ask for the fragment, or None if the fragment is not present. */
+    maybeFragment[String].matchRawUrl(sampleUrl) should be(Right(Some("the-ref")))
+    maybeFragment[String].matchRawUrl(sampleUrlWithoutFragment) should be(Right(None))
+
+    /** When your [[urldsl.language.Fragment]] is optional, you can rely on the extra `getOrElse` method. */
+    val stringOrDefault = maybeFragment[String].getOrElse("default value")
+    stringOrDefault.matchRawUrl(sampleUrl) should be(Right("the-ref"))
+    stringOrDefault.matchRawUrl(sampleUrlWithoutFragment) should be(Right("default value"))
+
+    /** Below we can witness the implicit conversion to a fragment. */
+    def askForFragment(
+        f: Fragment[Unit, SimpleFragmentMatchingError]
+    ): Fragment[Unit, SimpleFragmentMatchingError] = f
+
+    askForFragment("the-ref").matchRawUrl(sampleUrl) should be(Right(()))
+
+  }
+
+}

--- a/shared/src/test/scala/urldsl/examples/PathSegmentExamples.scala
+++ b/shared/src/test/scala/urldsl/examples/PathSegmentExamples.scala
@@ -1,0 +1,148 @@
+package urldsl.examples
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import urldsl.errors.SimplePathMatchingError
+import urldsl.vocabulary.{Codec, Segment}
+
+/**
+  * This class exposes some example of usage of the [[urldsl.language.PathSegment]] class.
+  *
+  * The `sampleUrl` used throughout this example class is defined in the [[urldsl.examples]] package object.
+  */
+final class PathSegmentExamples extends AnyFlatSpec with Matchers {
+
+  /** The following import brings everything you need for [[urldsl.language.PathSegment]] usage. */
+  import urldsl.language.PathSegment.simplePathErrorImpl._
+
+  "Some matching examples" should "work" in {
+
+    /** `root` is a "dummy" matcher which matches anything. It returns [[Unit]] when matching. */
+    root.matchRawUrl(sampleUrl) should be(Right(()))
+
+    /**
+      * Appending a specific segment value to the root in order to match the first segment.
+      * It returns Unit when matching, since we assume that the information is already known (it's "foo").
+      */
+    (root / "foo").matchRawUrl(sampleUrl) should be(Right(()))
+
+    /**
+      * Appending a [[String]] segmennt in order to retrieve the information contained in the first segment.
+      */
+    (root / segment[String]).matchRawUrl(sampleUrl) should be(Right("foo"))
+
+    /** You can also directly match other types than [[String]] (if you have the right implicits in scope). */
+    (root / "foo" / segment[Int]).matchRawUrl(sampleUrl) should be(Right(23))
+    (root / "foo" / 23 / segment[Boolean]).matchRawUrl(sampleUrl) should be(Right(true))
+
+    /** Note that a segment of [[String]] will always manage to match, but of course you get a ... [[String]]. */
+    (root / "foo" / segment[String]).matchRawUrl(sampleUrl) should be(Right("23"))
+
+    /** You can of course match several things at once, in which case outputs are "tupled". */
+    (root / "foo" / segment[Int] / segment[Boolean]).matchRawUrl(sampleUrl) should be(Right((23, true)))
+    (root / segment[String] / segment[Int] / segment[Boolean]).matchRawUrl(sampleUrl) should be(
+      Right(("foo", 23, true))
+    )
+
+    /**
+      * You can compose things the way you like, "pre-computing" segments.
+      *
+      * The `/` operator is *associative*, which means that the "place where you put parenthesis" doesn't matter. In
+      * the same way that (3+4)+5 = 3+(4+5), you have that `(s1 / s2) / s3 = s1 / (s2 / s3)`. Note that they won't be
+      * equal as Scala objects, but they will be for any (relevant) observable behaviour. (Technical note: it's not
+      * entirely true if you go crazy in tupling things.)
+      */
+    val s1 = segment[String]
+    val s2 = segment[Int]
+    val s3 = segment[Boolean]
+    (s1 / (s2 / s3)).matchRawUrl(sampleUrl) should be(((s1 / s2) / s3).matchRawUrl(sampleUrl))
+
+    /** You can also "group" several segments into a more meaningful class than a pair or a triplet. */
+    case class Stuff(str: String, j: Int)
+
+    (s1 / s2).as((Stuff.apply _).tupled, Stuff.unapply(_: Stuff).get).matchRawUrl(sampleUrl) should be(
+      Right(Stuff("foo", 23))
+    )
+
+    /** Or conveniently with an implicit [[urldsl.vocabulary.Codec]] */
+    implicit val stuffCodec: Codec[(String, Int), Stuff] =
+      Codec.factory((Stuff.apply _).tupled, Stuff.unapply(_: Stuff).get)
+
+    (s1 / s2).as[Stuff].matchRawUrl(sampleUrl) should be(Right(Stuff("foo", 23)))
+
+    /** [[urldsl.language.PathSegment]] can also be filtered to add some more restriction on the matching. */
+    s1.filter(_.length > 2, _ => SimplePathMatchingError.SimpleError("too short")).matchRawUrl(sampleUrl) should be(
+      Right("foo")
+    )
+    s1.filter(_.length > 3, _ => SimplePathMatchingError.SimpleError("too short")).matchRawUrl(sampleUrl) should be(
+      Left(
+        SimplePathMatchingError.SimpleError("too short")
+      )
+    )
+
+    /**
+      * As you probably noticed, [[urldsl.language.PathSegment]] are immutable objects and hence, can be reused freely.
+      */
+    (s1 / s1).matchRawUrl(sampleUrl) should be(Right("foo", "23"))
+
+    /**
+      * You also have the ability to compose [[urldsl.language.PathSegment]] "horizontally", by "branching" several
+      * possibilities
+      */
+    (root / (segment[Int] || segment[String])).matchRawUrl(sampleUrl) should be(Right(Right("foo")))
+
+    /**
+      * The [[urldsl.language.PathSegment]] trait is also very general, and while part of its power comes from its
+      * great "composability", it also comes from its ability to make quite generic things.
+      * One example is imposing that the path has ended.
+      */
+    (root / "foo" / 23 / true / endOfSegments).matchRawUrl(sampleUrl) should be(Right(()))
+    (root / "foo" / endOfSegments).matchRawUrl(sampleUrl) should be(
+      Left(
+        SimplePathMatchingError.EndOfSegmentRequired(
+          // this is the list of segments that were still present when reaching the `endOfSegments`
+          List(
+            Segment("23"),
+            Segment("true")
+          )
+        )
+      )
+    )
+
+  }
+
+  "Some matching examples" should "fail" in {
+
+    /** When trying to match a type that can not be created from the segment [[String]], it fails. */
+    (root / segment[Int]).matchRawUrl(sampleUrl) should be(
+      Left(
+        SimplePathMatchingError.SimpleError("""For input string: "foo"""")
+      )
+    )
+
+    /** It also fails if you want to consume more segments than there is. */
+    (root / "foo" / 23 / true / "other").matchRawUrl(sampleUrl) should be(
+      Left(SimplePathMatchingError.MissingSegment)
+    )
+
+    /** Asking for the wrong segment will fail as well. */
+    (root / "not-good").matchRawUrl(sampleUrl) should be(
+      Left(
+        SimplePathMatchingError.WrongValue("not-good", "foo")
+      )
+    )
+
+  }
+
+  "Some generating examples" should "work" in {
+
+    /**
+      * You can also use [[urldsl.language.PathSegment]]s for generating paths.
+      * Note that the strength of urldsl is that the `createPart` method is typesafe and knows what the path expects
+      * as information in order to generate the path string.
+      */
+    (root / segment[String] / segment[Int] / "hey").createPart(("hello", 22)) should be("hello/22/hey")
+
+  }
+
+}

--- a/shared/src/test/scala/urldsl/examples/QueryParamsExamples.scala
+++ b/shared/src/test/scala/urldsl/examples/QueryParamsExamples.scala
@@ -1,0 +1,121 @@
+package urldsl.examples
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import urldsl.errors.SimpleParamMatchingError
+
+/**
+  * This class exposes some example of usage of the [[urldsl.language.QueryParameters]] class.
+  *
+  * The `sampleUrl` used throughout this example class is defined in the [[urldsl.examples]] package object.
+  */
+final class QueryParamsExamples extends AnyFlatSpec with Matchers {
+
+  import urldsl.language.simpleErrorImpl._
+
+  "Some matching examples" should "work" in {
+
+    /**
+      * You can match a simple information from the query parameter.
+      * This param will look for the parameter "bar" in the query string.
+      */
+    param[String]("bar").matchRawUrl(sampleUrl) should be(Right("stuff"))
+
+    /** By default, special symbols are decoded automatically. */
+    param[String]("babar").matchRawUrl(sampleUrl) should be(Right("other stuff"))
+
+    /** You can ask to read a query parameter as a specific type, as long as the right implicits are in scope. */
+    param[Boolean]("ok").matchRawUrl(sampleUrl) should be(Right(true))
+
+    /** But you can always match the same parameter as a string. */
+    param[String]("ok").matchRawUrl(sampleUrl) should be(Right("true"))
+
+    /**
+      * Sometimes parameters are actually a list of parameters with the same key. You can read this as well.
+      * Note that we sort the list for the check, since the actual order is somewhat unpredictable (although
+      * deterministic).
+      */
+    listParam[Int]("other").matchRawUrl(sampleUrl).map(_.sorted) should be(Right(List(2, 3)))
+
+    /** You can compose several [[urldsl.language.QueryParameters]] with the `&` operator. */
+    (param[String]("bar") & param[String]("babar")).matchRawUrl(sampleUrl) should be(
+      Right(("stuff", "other stuff"))
+    )
+
+    /** Swapping the operands will match the same query strings, but the output is interchanged! */
+    (param[String]("babar") & param[String]("bar")).matchRawUrl(sampleUrl) should be(
+      Right(("other stuff", "stuff"))
+    )
+
+    /**
+      * If you want your parameters to match optionally, you can ascribe your [[urldsl.language.QueryParameters]] with
+      * `.?`.
+      */
+    param[String]("does-not-exist").?.matchRawUrl(sampleUrl) should be(Right(None))
+    param[String]("bar").?.matchRawUrl(sampleUrl) should be(Right(Some("stuff")))
+
+    /**
+      * [[urldsl.language.QueryParameters]] have a filter method allowing to restrict the things it matches.
+      */
+    param[String]("bar").filter(_.length > 3, _ => "too short").matchRawUrl(sampleUrl) should be(
+      Right(
+        "stuff"
+      )
+    )
+    // Note: this is poorly typed as the error type is Any, here.
+    param[String]("bar").filter(_.length > 10, _ => "too short").matchRawUrl(sampleUrl) should be(
+      Left(
+        "too short"
+      )
+    )
+
+    /**
+      * The filter and ? combinators can be conveniently combined together.
+      * This is because ? erases any previously encountered error and returns None.
+      */
+    param[String]("bar")
+      .filter(_.length > 10, _ => SimpleParamMatchingError.FromThrowable(new RuntimeException("too short")))
+      .?
+      .matchRawUrl(sampleUrl) should be(Right(None))
+
+  }
+
+  "Some matching examples" should "fail" in {
+
+    /** Trying to ask for an absent parameter leads to an error */
+    param[String]("does-not-exist").matchRawUrl(sampleUrl) should be(
+      Left(SimpleParamMatchingError.MissingParameterError("does-not-exist"))
+    )
+
+    /** Trying to decode with the wrong type leads to an error. */
+    param[Double]("bar")
+      .matchRawUrl(sampleUrl)
+      .swap
+      .map(_.isInstanceOf[SimpleParamMatchingError.FromThrowable])
+      .swap should be(
+      Left(true)
+    )
+
+    /**
+      * [[urldsl.language.QueryParameters]] are immutable objects, but used in a single parameter search, this fact is
+      * probably often useless. However, you can re-use it to combine with other parameters.
+      */
+    val p = param[Int]("other")
+    (p & p).matchRawUrl(sampleUrl) should be(Left(SimpleParamMatchingError.MissingParameterError("other")))
+
+  }
+
+  "Some generating examples" should "work" in {
+
+    /** You can also use [[urldsl.language.QueryParameters]] for generating query String */
+    (param[String]("p1") & param[Int]("p2")).createPart(("a string", 24)) should be(
+      """p1=a%20string&p2=24"""
+    )
+
+    (param[String]("p1") & listParam[String]("p2")).createPart(("hey", List("one", "two"))) should be(
+      """p1=hey&p2=one&p2=two"""
+    )
+
+  }
+
+}

--- a/shared/src/test/scala/urldsl/examples/RouterUseCaseExample.scala
+++ b/shared/src/test/scala/urldsl/examples/RouterUseCaseExample.scala
@@ -1,0 +1,96 @@
+package urldsl.examples
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import urldsl.language.UrlPart.SimpleUrlPart
+import urldsl.vocabulary.{PathQueryFragmentMatching, UrlMatching}
+
+/**
+  * This class shows a possible implementation of a Router. This could be used in a web frontend (using Scala.js) for
+  * displaying the correct component, or in a web server for triggering the action corresponding to the calling route.
+  *
+  * All abstract models are actually instances of [[urldsl.language.UrlPart]], which easily allows to abstract away
+  * the concrete choice the user could make as to how they want to match the URL. In this case, we will simply return
+  * a value based on what was extracted from the route. This value will be an instance of the
+  * [[urldsl.examples.RouterUseCaseExample#Output]], so that we can easily test that the correct route was called.
+  *
+  * We use the [[urldsl.errors.DummyError]] implementations since we really want to route correctly, we don't care about
+  * why a particular url was not matched.
+  */
+final class RouterUseCaseExample extends AnyFlatSpec with Matchers {
+
+  val beginUrl = "http://www.stuff.be/"
+
+  case class Output(value: String)
+
+  import urldsl.language.dummyErrorImpl._
+
+  /** Link a [[urldsl.language.UrlPart]] matching some routes, to an action using the information extracted from the route. */
+  sealed trait Route[T] {
+    def urlPart: SimpleUrlPart[T]
+    def action(t: T): Output
+
+    final def apply(rawUrl: String): Option[Output] = urlPart.matchRawUrl(rawUrl).map(action).toOption
+  }
+
+  object Route {
+    def apply[T](urlPart0: SimpleUrlPart[T])(action0: T => Output): Route[T] = new Route[T] {
+      val urlPart: SimpleUrlPart[T] = urlPart0
+      def action(t: T): Output = action0(t)
+    }
+  }
+
+  /** Collection of [[Route]] to be tried in order when calling with a given url. */
+  case class Router(routes: List[Route[_]]) {
+
+    /**
+      * Sequentially tries to match the given url with all the routes, and call the action of the first matching.
+      */
+    def maybeCallAction(rawUrl: String): Option[Output] =
+      routes.view
+        .map(_(rawUrl))
+        .collectFirst {
+          case Some(output) => output
+        }
+
+    /** Same as maybeCallAction with a default output when no match is found. */
+    def callActionWithDefault(rawUrl: String, default: Output): Output = maybeCallAction(rawUrl).getOrElse(default)
+  }
+
+  object Router {
+    def apply(routes: Route[_]*): Router = Router(routes.toList)
+  }
+
+  "Router" should "work" in {
+
+    Router().maybeCallAction("") should be(None)
+
+    val notFound = root / 404
+
+    /** Definition of the router, with in-order defined routes. */
+    val theRouter = Router(
+      Route(root / endOfSegments)(_ => Output("home")),
+      Route((root / "users").withFragment(fragment[String]).fragmentOnly)(
+        (ref: String) => Output(s"Users view with fragment $ref")
+      ),
+      Route(((root / "admin") ? param[String]("username")).withFragment(fragment[String])) {
+        case PathQueryFragmentMatching(_, query, f) => Output(s"Admin view for $query at $f")
+      },
+      Route((root / "admin") ? param[String]("username")) {
+        case UrlMatching(_, username) => Output(s"Welcome, $username")
+      },
+      Route(root / "admin")(_ => Output("admin view.")),
+      Route(notFound)(_ => Output("not found"))
+    )
+
+    /** Checks that the correct output is called with the given url. */
+    theRouter.maybeCallAction(beginUrl) should be(Some(Output("home")))
+    theRouter.maybeCallAction(beginUrl ++ "users#info") should be(Some(Output("Users view with fragment info")))
+    theRouter.maybeCallAction(beginUrl ++ "admin") should be(Some(Output("admin view.")))
+    theRouter.maybeCallAction(beginUrl ++ "admin?username=Antoine") should be(Some(Output("Welcome, Antoine")))
+    theRouter.maybeCallAction(beginUrl ++ "404") should be(Some(Output("not found")))
+    theRouter.maybeCallAction(beginUrl ++ "does-not-exist") should be(None)
+
+  }
+
+}

--- a/shared/src/test/scala/urldsl/examples/package.scala
+++ b/shared/src/test/scala/urldsl/examples/package.scala
@@ -11,4 +11,6 @@ package urldsl
   */
 package object examples {
   val sampleUrl = "http://www.some-domain.be/foo/23/true?bar=stuff&babar=other%20stuff&other=2&other=3&ok=true#the-ref"
+  val sampleUrlWithoutFragment =
+    "http://www.some-domain.be/foo/23/true?bar=stuff&babar=other%20stuff&other=2&other=3&ok=true"
 }

--- a/shared/src/test/scala/urldsl/examples/package.scala
+++ b/shared/src/test/scala/urldsl/examples/package.scala
@@ -10,5 +10,5 @@ package urldsl
   * url-dsl for generating urls, and not for parsing them.
   */
 package object examples {
-  val sampleUrl = "http://www.some-domain.be/foo/23/true?bar=stuff&babar=other%20stuff#the-ref"
+  val sampleUrl = "http://www.some-domain.be/foo/23/true?bar=stuff&babar=other%20stuff&other=2&other=3&ok=true#the-ref"
 }

--- a/shared/src/test/scala/urldsl/examples/package.scala
+++ b/shared/src/test/scala/urldsl/examples/package.scala
@@ -1,0 +1,14 @@
+package urldsl
+
+/**
+  * This package shows examples of usage of url-dsl.
+  *
+  * When using url-dsl, you are free to chose any error adt system that you want. There are two
+  * built-in for you, the [[urldsl.errors.SimplePathMatchingError]] (and siblings) and the
+  * [[urldsl.errors.DummyError]]. We will use the former in these example. The latter being perfect
+  * in cases where you don't care about what caused the error (for example a router) or when you use primarily
+  * url-dsl for generating urls, and not for parsing them.
+  */
+package object examples {
+  val sampleUrl = "http://www.some-domain.be/foo/23/true?bar=stuff&babar=other%20stuff#the-ref"
+}

--- a/shared/src/test/scala/urldsl/language/AllImplSpec.scala
+++ b/shared/src/test/scala/urldsl/language/AllImplSpec.scala
@@ -1,0 +1,39 @@
+package urldsl.language
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import urldsl.vocabulary.UrlMatching
+
+/** Simple specs to test whether everything combines nicely. */
+//noinspection TypeAnnotation
+final class AllImplSpec extends AnyFlatSpec with Matchers {
+
+  import simpleErrorImpl._
+
+  val sampleUrl = "http://www.some-domain.be/hey/you/23?what=foo&who=babar#some-fragment"
+
+  val anySegment = segment[String].ignore("any")
+  val path = root / "hey" / anySegment / segment[Int]
+  val query = param[String]("what")
+  val ref = fragment[String]
+
+  "Simple individual matching" should "work" in {
+
+    path.matchRawUrl(sampleUrl) should be(Right(23))
+    query.matchRawUrl(sampleUrl) should be(Right("foo"))
+    ref.matchRawUrl(sampleUrl) should be(Right("some-fragment"))
+
+  }
+
+  "Associating path and query" should "be the same as path and query separately" in {
+
+    (path ? query).matchRawUrl(sampleUrl) should be(for {
+      p <- path.matchRawUrl(sampleUrl)
+      q <- query.matchRawUrl(sampleUrl)
+    } yield UrlMatching(p, q))
+
+  }
+
+  "Associating path and fragment" should "be the same as path and fragment separately" in {}
+
+}

--- a/shared/src/test/scala/urldsl/language/AllImplSpec.scala
+++ b/shared/src/test/scala/urldsl/language/AllImplSpec.scala
@@ -2,7 +2,7 @@ package urldsl.language
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import urldsl.errors.SimplePathMatchingError
+import urldsl.errors.{SimpleFragmentMatchingError, SimplePathMatchingError}
 import urldsl.vocabulary.{PathQueryFragmentMatching, UrlMatching}
 
 /** Simple specs to test whether everything combines nicely. */
@@ -19,11 +19,9 @@ final class AllImplSpec extends AnyFlatSpec with Matchers {
   val ref = fragment[String]
 
   "Simple individual matching" should "work" in {
-
     path.matchRawUrl(sampleUrl) should be(Right(23))
     query.matchRawUrl(sampleUrl) should be(Right("foo"))
     ref.matchRawUrl(sampleUrl) should be(Right("some-fragment"))
-
   }
 
   "Associating path and query" should "be the same as path and query separately" in {
@@ -55,12 +53,23 @@ final class AllImplSpec extends AnyFlatSpec with Matchers {
   def askForPath[T](pathSegment: PathSegment[T, SimplePathMatchingError]): PathSegment[T, SimplePathMatchingError] =
     pathSegment
 
+  def askForFragment[T](
+      fragment: Fragment[T, SimpleFragmentMatchingError]
+  ): Fragment[T, SimpleFragmentMatchingError] = fragment
+
   "Implicit conversion" should "be called with the specified error system" in {
-
     askForPath("hey").matchRawUrl(sampleUrl).isRight should be(true)
-
     (anySegment / anySegment / askForPath(23)).matchRawUrl(sampleUrl) should be(Right(()))
+    askForFragment("some-fragment").matchRawUrl(sampleUrl).isRight should be(true)
+    (anySegment / anySegment / segment[Int]).withFragment("some-fragment").matchRawUrl(sampleUrl) should be(
+      Right(PathQueryFragmentMatching(23, (), ()))
+    )
+  }
 
+  "Asking for a fragment" should "automatically find the correct error system" in {
+    (anySegment / anySegment / segment[Int]).withFragment(maybeFragment[String]).matchRawUrl(sampleUrl) should be(
+      Right(PathQueryFragmentMatching(23, (), Some("some-fragment")))
+    )
   }
 
 }

--- a/shared/src/test/scala/urldsl/language/AllImplSpec.scala
+++ b/shared/src/test/scala/urldsl/language/AllImplSpec.scala
@@ -2,7 +2,8 @@ package urldsl.language
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import urldsl.vocabulary.UrlMatching
+import urldsl.errors.SimplePathMatchingError
+import urldsl.vocabulary.{PathQueryFragmentMatching, UrlMatching}
 
 /** Simple specs to test whether everything combines nicely. */
 //noinspection TypeAnnotation
@@ -34,6 +35,32 @@ final class AllImplSpec extends AnyFlatSpec with Matchers {
 
   }
 
-  "Associating path and fragment" should "be the same as path and fragment separately" in {}
+  "Associating path and fragment" should "be the same as path and fragment separately" in {
+    path.withFragment(ref).matchRawUrl(sampleUrl) should be(for {
+      p <- path.matchRawUrl(sampleUrl)
+      f <- ref.matchRawUrl(sampleUrl)
+    } yield PathQueryFragmentMatching(p, (), f))
+  }
+
+  "Associating path, query and fragment" should "be the same as the three separately" in {
+
+    (path ? query).withFragment(ref).matchRawUrl(sampleUrl) should be(for {
+      p <- path.matchRawUrl(sampleUrl)
+      q <- query.matchRawUrl(sampleUrl)
+      f <- ref.matchRawUrl(sampleUrl)
+    } yield PathQueryFragmentMatching(p, q, f))
+
+  }
+
+  def askForPath[T](pathSegment: PathSegment[T, SimplePathMatchingError]): PathSegment[T, SimplePathMatchingError] =
+    pathSegment
+
+  "Implicit conversion" should "be called with the specified error system" in {
+
+    askForPath("hey").matchRawUrl(sampleUrl).isRight should be(true)
+
+    (anySegment / anySegment / askForPath(23)).matchRawUrl(sampleUrl) should be(Right(()))
+
+  }
 
 }

--- a/shared/src/test/scala/urldsl/language/FilteringProperties.scala
+++ b/shared/src/test/scala/urldsl/language/FilteringProperties.scala
@@ -1,0 +1,29 @@
+package urldsl.language
+
+import org.scalacheck._
+import org.scalacheck.Prop._
+import urldsl.language.simpleErrorImpl._
+import urldsl.vocabulary.{MaybeFragment, Param, Segment}
+
+object FilteringProperties extends Properties("Filtering") {
+
+  def predicate(x: Int): Boolean = x % 2 == 0
+
+  property("Filtering segment on even integers") = forAll(Gen.posNum[Int]) { (number: Int) =>
+    segment[Int].filter(predicate, _ => ()).matchSegments(List(Segment(number.toString))).isRight == predicate(number)
+  }
+
+  property("Filtering query param on event integers") = forAll(Gen.posNum[Int]) { (number: Int) =>
+    param[Int]("num")
+      .filter(predicate, _ => ())
+      .matchParams(Map("num" -> Param(List(number.toString))))
+      .isRight == predicate(number)
+  }
+
+  property("Filtering fragment on even integers") = forAll(Gen.posNum[Int]) { (number: Int) =>
+    fragment[Int].filter(predicate, _ => ()).matchFragment(MaybeFragment(Some(number.toString))).isRight == predicate(
+      number
+    )
+  }
+
+}

--- a/shared/src/test/scala/urldsl/language/FragmentProperties.scala
+++ b/shared/src/test/scala/urldsl/language/FragmentProperties.scala
@@ -1,0 +1,8 @@
+package urldsl.language
+
+import org.scalacheck._
+import urldsl.errors.DummyError
+import urldsl.errors.DummyError.{dummyErrorIsPathMatchingError => e}
+import urldsl.vocabulary.{PathMatchOutput, Segment}
+
+final class FragmentProperties {}

--- a/shared/src/test/scala/urldsl/language/FragmentProperties.scala
+++ b/shared/src/test/scala/urldsl/language/FragmentProperties.scala
@@ -1,8 +1,65 @@
 package urldsl.language
 
 import org.scalacheck._
-import urldsl.errors.DummyError
-import urldsl.errors.DummyError.{dummyErrorIsPathMatchingError => e}
-import urldsl.vocabulary.{PathMatchOutput, Segment}
+import org.scalacheck.Prop._
+import urldsl.errors.SimpleFragmentMatchingError
+import urldsl.vocabulary.MaybeFragment
 
-final class FragmentProperties {}
+import scala.util.Try
+import urldsl.language.Fragment.simpleFragmentErrorImpl._
+
+//noinspection TypeAnnotation
+final class FragmentProperties extends Properties("Fragment") {
+
+  val fragmentGen: Gen[MaybeFragment] = Gen.option(Gen.asciiStr).map(MaybeFragment)
+  val intFragmentGen: Gen[MaybeFragment] = Gen.chooseNum(-1000, 1000).map(_.toString).map(Some(_)).map(MaybeFragment)
+
+  val nonIntFragmentGen: Gen[MaybeFragment] = fragmentGen.filter {
+    case MaybeFragment(Some(value)) => Try(value.toInt).isFailure
+    case _                          => true
+  }
+
+  val stringFragment = fragment[String]
+  val maybeStringFragment = maybeFragment[String]
+  val intFragment = fragment[Int]
+  val maybeIntFragment = maybeFragment[Int]
+
+  property("fragment gen sometimes generate empty fragment") = exists(fragmentGen)(_.isEmpty)
+
+  property("Maybe Matching existing string always works") = forAll(fragmentGen) { fragment =>
+    maybeStringFragment.matchFragment(fragment).isRight
+  }
+
+  property("Matching existing string works when fragment is non empty") = forAll(fragmentGen) { fragment =>
+    (stringFragment.matchFragment(fragment), fragment) match {
+      case (Left(value), MaybeFragment(None)) => Prop(value == SimpleFragmentMatchingError.MissingFragmentError)
+      case (Left(error), MaybeFragment(Some(value))) =>
+        Prop(false) :| s"Fragment contained value $value but I got the error $error"
+      case (Right(value), MaybeFragment(None)) =>
+        Prop(false) :| s"Fragment was empty and yet I extracted the value $value"
+      case (Right(extractedValue), MaybeFragment(Some(value))) =>
+        Prop(extractedValue == value) :| s"Fragment extracted the value $extractedValue but was supposed to get $value."
+    }
+  }
+
+  property("Empty matching matches when fragment is empty") = forAll(fragmentGen) { fragment =>
+    emptyFragment.matchFragment(fragment).isRight == fragment.isEmpty
+  }
+
+  property("Matching an integer works") = forAll(intFragmentGen) { fragment =>
+    intFragment.matchFragment(fragment).map(_.toString).map(Some(_)) == Right(fragment.value)
+  }
+
+  property("Int matching always fail when it's not an int") = forAll(nonIntFragmentGen) { fragment =>
+    intFragment.matchFragment(fragment) match {
+      case Right(value) => Prop(false) :| s"This was supposed to not match but I got $value"
+      case Left(error) =>
+        Prop(fragment.value match {
+          case Some(value) => error.isInstanceOf[SimpleFragmentMatchingError.FromThrowable]
+          case None        => error == SimpleFragmentMatchingError.MissingFragmentError
+        }) :| s"Correctly found out that it was an error but error was wrong, got: $error"
+
+    }
+  }
+
+}

--- a/shared/src/test/scala/urldsl/language/FragmentProperties.scala
+++ b/shared/src/test/scala/urldsl/language/FragmentProperties.scala
@@ -55,11 +55,29 @@ final class FragmentProperties extends Properties("Fragment") {
       case Right(value) => Prop(false) :| s"This was supposed to not match but I got $value"
       case Left(error) =>
         Prop(fragment.value match {
-          case Some(value) => error.isInstanceOf[SimpleFragmentMatchingError.FromThrowable]
-          case None        => error == SimpleFragmentMatchingError.MissingFragmentError
+          case Some(_) => error.isInstanceOf[SimpleFragmentMatchingError.FromThrowable]
+          case None    => error == SimpleFragmentMatchingError.MissingFragmentError
         }) :| s"Correctly found out that it was an error but error was wrong, got: $error"
 
     }
+  }
+
+  property("Mapping string results to its length works") = forAll(fragmentGen) { fragment =>
+    val stringLengthFragment = stringFragment.as((_: String).length, (_: Int).toString)
+
+    Prop(fragment.nonEmpty) ==> Prop(
+      stringLengthFragment.matchFragment(fragment) == Right(fragment.value.get.length)
+    )
+  }
+
+  property("Matching is the left inverse for generating in string fragment") = forAll(Gen.asciiStr) {
+    (fragment: String) =>
+      stringFragment.matchFragment(stringFragment.createFragment(fragment)) == Right(fragment)
+  }
+
+  property("Matching is the left inverse for generating in int fragment") = forAll(Gen.chooseNum(-1000, 1000)) {
+    (fragment: Int) =>
+      intFragment.matchFragment(intFragment.createFragment(fragment)) == Right(fragment)
   }
 
 }

--- a/shared/src/test/scala/urldsl/language/FragmentRawUrlSpec.scala
+++ b/shared/src/test/scala/urldsl/language/FragmentRawUrlSpec.scala
@@ -1,0 +1,21 @@
+package urldsl.language
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import urldsl.language.Fragment.simpleFragmentErrorImpl._
+
+//noinspection TypeAnnotation
+final class FragmentRawUrlSpec extends AnyFlatSpec with Matchers {
+
+  val stringFragment = fragment[String]
+
+  "Generating a fragment with a space" should "put %20 instead" in {
+    val str = "hey friends"
+    stringFragment.createPart(str) should be("#" ++ str.replaceAll(" ", "%20"))
+  }
+
+  "Generating a fragment from an empty string" should "give the empty string" in {
+    stringFragment.createPart("") should be("")
+  }
+
+}

--- a/shared/src/test/scala/urldsl/language/PathSegmentProperties.scala
+++ b/shared/src/test/scala/urldsl/language/PathSegmentProperties.scala
@@ -84,7 +84,9 @@ final class PathSegmentProperties extends Properties("PathSegment") {
   }
 
   property("IntSegmentComplains") = forAll(Gen.nonEmptyListOf(nonIntSegmentGen)) { ls: List[Segment] =>
-    ($ / segment[Int]).matchSegments(ls) == Left(e.malformed(ls.head.content))
+    val matchResult = ($ / segment[Int]).matchSegments(ls)
+    val expectedResult = Left(e.malformed(ls.head.content))
+    Prop(matchResult == expectedResult) :| s"Match result was $matchResult but I needed $expectedResult"
   }
 
   property("oneOfValuesMatches") = forAll(Gen.nonEmptyListOf(segmentGen)) { ls: List[Segment] =>

--- a/shared/src/test/scala/urldsl/language/QueryParamsUrlSpec.scala
+++ b/shared/src/test/scala/urldsl/language/QueryParamsUrlSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import urldsl.errors.DummyError
 import urldsl.language.QueryParameters.dummyErrorImpl._
-import urldsl.language.QueryParameters.dummyErrorImpl.{empty => root}
+import urldsl.language.QueryParameters.dummyErrorImpl.{ignore => root}
 import urldsl.vocabulary.Codec
 
 final class QueryParamsUrlSpec extends AnyFlatSpec with Matchers {

--- a/shared/src/test/scala/urldsl/language/QueryParamsUrlSpec.scala
+++ b/shared/src/test/scala/urldsl/language/QueryParamsUrlSpec.scala
@@ -7,7 +7,7 @@ import urldsl.language.QueryParameters.dummyErrorImpl._
 import urldsl.language.QueryParameters.dummyErrorImpl.{empty => root}
 import urldsl.vocabulary.Codec
 
-final class QueryParamsRawUrlSpec extends AnyFlatSpec with Matchers {
+final class QueryParamsUrlSpec extends AnyFlatSpec with Matchers {
 
   private implicit class QueryParamsEnhanced[Q](qp: QueryParameters[Q, DummyError]) {
     def params(q: Q): String = qp.createParamsString(q)

--- a/shared/src/test/scala/urldsl/url/UrlParserSpec.scala
+++ b/shared/src/test/scala/urldsl/url/UrlParserSpec.scala
@@ -1,0 +1,29 @@
+package urldsl.url
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+//noinspection TypeAnnotation
+final class UrlParserSpec extends AnyFlatSpec with Matchers {
+
+  val parserGenerator = UrlStringParserGenerator.defaultUrlStringParserGenerator
+
+  val sampleUrl = "https://scala-lang.org/hello?q=3"
+  val fragment = "hey"
+  val sampleUrlWithFragment = sampleUrl ++ "#" ++ fragment
+
+  val hashtagEndingUrl = sampleUrl ++ "#"
+
+  "A url without fragment" should "issue None when parsing" in {
+    parserGenerator.parser(sampleUrl).maybeFragment should be(None)
+  }
+
+  "A url with fragment" should "issue some when parsing" in {
+    parserGenerator.parser(sampleUrlWithFragment).maybeFragment should be(Some(fragment))
+  }
+
+  "A url ending with #" should "issue None when parsing" in {
+    parserGenerator.parser(hashtagEndingUrl).maybeFragment should be(None)
+  }
+
+}


### PR DESCRIPTION
This pull request mainly adds the fragment functionality to url-dsl.

A path, query, or their combination can now use the `withFragment` method in order to extract the fragment information (or check whether it is something special, or even verify that it's empty).

The pull request also introduces the `UrlPart` trait, abstracting all other in order to unify their use, whenever relevant.

Tests contain an `examples` package with comprehensive set of documented examples, to get you started.