### PR TITLE
Make AllImpl instances lazy to reduce JS bundle size if unused

### DIFF
--- a/shared/src/main/scala/urldsl/language/package.scala
+++ b/shared/src/main/scala/urldsl/language/package.scala
@@ -12,8 +12,8 @@ import urldsl.errors.{
 
 package object language {
 
-  val dummyErrorImpl: AllImpl[DummyError, DummyError, DummyError] = AllImpl[DummyError, DummyError, DummyError]
-  val simpleErrorImpl: AllImpl[SimplePathMatchingError, SimpleParamMatchingError, SimpleFragmentMatchingError] =
+  lazy val dummyErrorImpl: AllImpl[DummyError, DummyError, DummyError] = AllImpl[DummyError, DummyError, DummyError]
+  lazy val simpleErrorImpl: AllImpl[SimplePathMatchingError, SimpleParamMatchingError, SimpleFragmentMatchingError] =
     AllImpl[SimplePathMatchingError, SimpleParamMatchingError, SimpleFragmentMatchingError]
 
 }


### PR DESCRIPTION
Most people will only use at most one of these instances. This change will prevent unused error classes from being added to the JS bundle.