### PR TITLE
Publish for Scala 3.0.0-RC3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ organization := "be.doeraene"
 inThisBuild(
   Def.settings(
     version := "0.3.2",
-    crossScalaVersions := Seq("3.0.0-RC2", "2.13.5", "2.12.13"),
+    crossScalaVersions := Seq("3.0.0-RC3", "3.0.0-RC2", "2.13.5", "2.12.13"),
     scalaVersion := crossScalaVersions.value.head,
     scalacOptions ++= Seq("-feature", "-deprecation")
   )
@@ -46,7 +46,7 @@ lazy val `shared` = crossProject(JSPlatform, JVMPlatform)
     description := "A tiny library for parsing and creating urls in a type-safe way",
     licenses := Seq("MIT" -> url("http://www.opensource.org/licenses/mit-license.php")),
     libraryDependencies ++= Seq(
-      "org.scalatest" %%% "scalatest" % "3.2.7" % "test",
+      "org.scalatest" %%% "scalatest" % (if (scalaVersion.value == "3.0.0-RC3") "3.2.8" else "3.2.7") % "test",
       "org.scalacheck" %%% "scalacheck" % "1.15.3" % "test"
     )
   )

--- a/shared/src/main/scala-3.0.0-RC3/urldsl/vocabulary/FromStringWithNumeric.scala
+++ b/shared/src/main/scala-3.0.0-RC3/urldsl/vocabulary/FromStringWithNumeric.scala
@@ -1,0 +1,18 @@
+package urldsl.vocabulary
+
+import urldsl.errors.ErrorFromThrowable
+
+trait FromStringWithNumeric {
+
+  implicit def numericFromString[T, A](
+      implicit num: Numeric[T],
+      fromThrowable: ErrorFromThrowable[A]
+  ): FromString[T, A] = FromString.factory(
+    s =>
+      num.parseString(s) match {
+        case Some(t) => Right(t)
+        case None    => Left(fromThrowable.fromThrowable(new Exception(s"$s is not numeric")))
+      }
+  )
+
+}


### PR DESCRIPTION
Publishing for both RC2 and RC3 will probably make life a bit easier for users on the cutting edge.

ScalaTest is a mild annoyance in that they didn't publish a version that works on both RC2 and RC3.

My suggestion is to keep publishing for the last two RC-s until 3.0.0 hits the shelves.