### PR TITLE
Bump to Scala 3.2.0 (and thus Scala.js 1.9.0) to avoid sourcemaps bug

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,8 +28,8 @@ organization := "be.doeraene"
 
 inThisBuild(
   Def.settings(
-    version := "0.4.0",
-    crossScalaVersions := Seq("3.0.0", "2.13.5", "2.12.13"),
+    version := "0.4.1",
+    crossScalaVersions := Seq("3.2.0", "2.13.5", "2.12.13"),
     scalaVersion := crossScalaVersions.value.head,
     scalacOptions ++= Seq("-feature", "-deprecation")
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.5.0")
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.9.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)


### PR DESCRIPTION
This one: https://github.com/lampepfl/dotty/issues/14240

As per [todays discussion](https://discord.com/channels/632150470000902164/635668814956068864/1024160318022230088) in scala-js Discord, I need to upgrade all dependencies of Laminar to Scala 3.2.0, which in turn requires upgrading them to Scala.js 1.9.0.

I'm not 100% sure how to set the Scala.js version that URL-DSL is published with. I updated the "default" Scala.js version to the new minimum workable one.

I technically don't need URL-DSL for Laminar itself, but I do need it for Waypoint. Could you please release this as 0.4.1?