### PR TITLE
Use Tuplez 0.4.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val `url-dsl` = crossProject(JSPlatform, JVMPlatform)
   .settings(name := "url-dsl")
   .settings(
     libraryDependencies ++= Seq(
-      "app.tulz" %%% "tuplez-full-light" % "0.3.8",
+      "app.tulz" %%% "tuplez-full-light" % "0.4.0",
       "org.scalatest" %%% "scalatest" % "3.2.14" % Test,
       "org.scalacheck" %%% "scalacheck" % "1.17.0" % Test,
       "org.scalameta" %%% "munit" % "0.7.29" % Test


### PR DESCRIPTION
More efficient Scala.js encoding of compose / decompose methods. See https://github.com/raquo/Laminar/issues/133#issuecomment-1455046222

Small change, should be invisible to users in practice, but it's binary-compat-breaking. I would like to include this in Laminar 15.0.0