### PR TITLE
Point source maps to github

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches: [publish]
     tags: ["*"]
+env:
+  CI: true
 jobs:
   publish:
     runs-on: ubuntu-20.04

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ '**' ]
 
+env:
+  CI: true
+
 jobs:
   build:
 

--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,9 @@ lazy val `url-dsl` = crossProject(JSPlatform, JVMPlatform)
       "org.scalatest" %%% "scalatest" % "3.2.14" % Test,
       "org.scalacheck" %%% "scalacheck" % "1.17.0" % Test,
       "org.scalameta" %%% "munit" % "0.7.29" % Test
+    ),
+    (Compile / doc / scalacOptions) ++= Seq(
+      "-no-link-warnings" // Suppress scaladoc "Could not find any member to link for" warnings
     )
   )
   .jsSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,15 @@ lazy val `url-dsl` = crossProject(JSPlatform, JVMPlatform)
       "org.scalameta" %%% "munit" % "0.7.29" % Test
     )
   )
+  .jsSettings(
+    scalacOptions ++= sys.env.get("CI").map { _ =>
+      val localSourcesPath = (LocalRootProject / baseDirectory).value.toURI
+      val remoteSourcesPath = s"https://raw.githubusercontent.com/sherpal/url-dsl/${git.gitHeadCommit.value.get}/"
+      val sourcesOptionName = if (scalaVersion.value.startsWith("2.")) "-P:scalajs:mapSourceURI" else "-scalajs-mapSourceURI"
+
+      s"${sourcesOptionName}:$localSourcesPath->$remoteSourcesPath"
+    }
+  )
   .jvmSettings(
     coverageFailOnMinimum := true,
     coverageMinimumStmtTotal := 99,


### PR DESCRIPTION
Heyo, currently URL-DSL source maps point to local files (in the CI's file system) which does not work for end users, who have no access to that. This PR is the standard fix that I've used across many projects. I verified that the correct URLs are included in sjsir files.

This does not affect binary or source compatibility, so this can be released as v0.6.1

... I? wish there was a better way to do this at scale, I've lost count of all the projects that needed this boilerplate. /minirant