### PR TITLE
Fixed a case with listParam where matching failed if no query parameters were provided in the URL, where as it should have returned `Nil`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ inThisBuild(
         url("https://github.com/sherpal")
       )
     ),
-    crossScalaVersions := Seq("3.2.0", "2.13.5", "2.12.13"),
+    crossScalaVersions := Seq("3.3.3", "2.13.14", "2.12.19"),
     scalaVersion := crossScalaVersions.value.head,
     autoAPIMappings := true
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.8.0
+sbt.version = 1.10.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.9.0")
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.16.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)

--- a/url-dsl/.js/src/main/scala/urldsl/url/JSUrlStringParser.scala
+++ b/url-dsl/.js/src/main/scala/urldsl/url/JSUrlStringParser.scala
@@ -12,7 +12,7 @@ final class JSUrlStringParser(val rawUrl: String) extends UrlStringParser {
 
   def maybeFragment: Option[String] =
     Option(urlParser.hash)
-    /*
+      /*
        * Empty fragment are considered to have no fragment at all
        */
       .filter(_.nonEmpty)

--- a/url-dsl/.js/src/main/scala/urldsl/url/URL.scala
+++ b/url-dsl/.js/src/main/scala/urldsl/url/URL.scala
@@ -8,22 +8,19 @@ import scala.scalajs.js.annotation.JSGlobal
 @JSGlobal
 private[url] final class URL(url: String) extends js.Object {
 
-  /**
-    * Is a DOMString containing an initial '/' followed by the path of the URL.
+  /** Is a DOMString containing an initial '/' followed by the path of the URL.
     *
     * MDN
     */
   var pathname: String = js.native
 
-  /**
-    * Is a DOMString containing a '?' followed by the parameters of the URL.
+  /** Is a DOMString containing a '?' followed by the parameters of the URL.
     *
     * MDN
     */
   var search: String = js.native
 
-  /**
-    * Is a DOMString containing a '#' followed by the fragment identifier of the URL.
+  /** Is a DOMString containing a '#' followed by the fragment identifier of the URL.
     *
     * MDN
     */

--- a/url-dsl/.jvm/src/main/scala/urldsl/url/JavaNetUrlStringParser.scala
+++ b/url-dsl/.jvm/src/main/scala/urldsl/url/JavaNetUrlStringParser.scala
@@ -1,10 +1,10 @@
 package urldsl.url
 
-import java.net.{URL, URLDecoder}
+import java.net.{URI, URLDecoder}
 
 final class JavaNetUrlStringParser(val rawUrl: String) extends UrlStringParser {
 
-  private val urlParser = new URL(rawUrl)
+  private val urlParser = URI.create(rawUrl).toURL()
 
   def queryParametersString: String = Option(urlParser.getQuery).getOrElse("")
 

--- a/url-dsl/src/main/scala-3/urldsl/vocabulary/FromStringWithNumeric.scala
+++ b/url-dsl/src/main/scala-3/urldsl/vocabulary/FromStringWithNumeric.scala
@@ -4,15 +4,14 @@ import urldsl.errors.ErrorFromThrowable
 
 trait FromStringWithNumeric {
 
-  implicit def numericFromString[T, A](
-      implicit num: Numeric[T],
+  implicit def numericFromString[T, A](implicit
+      num: Numeric[T],
       fromThrowable: ErrorFromThrowable[A]
-  ): FromString[T, A] = FromString.factory(
-    s =>
-      num.parseString(s) match {
-        case Some(t) => Right(t)
-        case None    => Left(fromThrowable.fromThrowable(new Exception(s"$s is not numeric")))
-      }
+  ): FromString[T, A] = FromString.factory(s =>
+    num.parseString(s) match {
+      case Some(t) => Right(t)
+      case None    => Left(fromThrowable.fromThrowable(new Exception(s"$s is not numeric")))
+    }
   )
 
 }

--- a/url-dsl/src/main/scala/urldsl/errors/DummyError.scala
+++ b/url-dsl/src/main/scala/urldsl/errors/DummyError.scala
@@ -1,8 +1,7 @@
 package urldsl.errors
 import urldsl.vocabulary.Segment
 
-/**
-  * Error type with only one instance, for when you only care about knowing whether the error exists.
+/** Error type with only one instance, for when you only care about knowing whether the error exists.
   */
 sealed trait DummyError
 

--- a/url-dsl/src/main/scala/urldsl/errors/ErrorFromThrowable.scala
+++ b/url-dsl/src/main/scala/urldsl/errors/ErrorFromThrowable.scala
@@ -1,10 +1,10 @@
 package urldsl.errors
 
-/**
-  * You can implement this trait for your own error type A, and give a implicit instance in order to use the
+/** You can implement this trait for your own error type A, and give a implicit instance in order to use the
   * functionality requiring it, e.g., in [[urldsl.vocabulary.FromString]].
   *
-  * @tparam A tye type of your error.
+  * @tparam A
+  *   tye type of your error.
   */
 trait ErrorFromThrowable[A] {
 

--- a/url-dsl/src/main/scala/urldsl/errors/ParamMatchingError.scala
+++ b/url-dsl/src/main/scala/urldsl/errors/ParamMatchingError.scala
@@ -1,13 +1,13 @@
 package urldsl.errors
 
-/**
-  * You can implement this trait for your own error type `A`, and provide an implicit instance in the companion object of
-  * `A` in order to use all pre-defined [[urldsl.language.QueryParameters]].
+/** You can implement this trait for your own error type `A`, and provide an implicit instance in the companion object
+  * of `A` in order to use all pre-defined [[urldsl.language.QueryParameters]].
   *
   * @example
-  *          See implementations of [[DummyError]] and [[SimpleParamMatchingError]]
+  *   See implementations of [[DummyError]] and [[SimpleParamMatchingError]]
   *
-  * @tparam A the type of your error.
+  * @tparam A
+  *   the type of your error.
   */
 trait ParamMatchingError[A] {
   def missingParameterError(paramName: String): A

--- a/url-dsl/src/main/scala/urldsl/errors/PathMatchingError.scala
+++ b/url-dsl/src/main/scala/urldsl/errors/PathMatchingError.scala
@@ -2,14 +2,14 @@ package urldsl.errors
 
 import urldsl.vocabulary.Segment
 
-/**
-  * You can implement this trait for your own error type `A`, a giving an implicit instance in the companion object of
+/** You can implement this trait for your own error type `A`, a giving an implicit instance in the companion object of
   * `A` so that it is available for all pre-defined [[urldsl.language.PathSegment]].
   *
   * @example
-  *          See implementations of [[DummyError]] or [[SimpleParamMatchingError]]
+  *   See implementations of [[DummyError]] or [[SimpleParamMatchingError]]
   *
-  * @tparam A type of the error.
+  * @tparam A
+  *   type of the error.
   */
 trait PathMatchingError[+A] {
 

--- a/url-dsl/src/main/scala/urldsl/errors/SimpleParamMatchingError.scala
+++ b/url-dsl/src/main/scala/urldsl/errors/SimpleParamMatchingError.scala
@@ -2,8 +2,7 @@ package urldsl.errors
 
 sealed trait SimpleParamMatchingError
 
-/**
-  * An implementation of [[ParamMatchingError]] that simply wraps the trigger of the error inside its components.
+/** An implementation of [[ParamMatchingError]] that simply wraps the trigger of the error inside its components.
   */
 object SimpleParamMatchingError {
 

--- a/url-dsl/src/main/scala/urldsl/language/AllImpl.scala
+++ b/url-dsl/src/main/scala/urldsl/language/AllImpl.scala
@@ -2,8 +2,7 @@ package urldsl.language
 
 import urldsl.errors.{FragmentMatchingError, ParamMatchingError, PathMatchingError}
 
-final class AllImpl[P, Q, F] private (
-    implicit
+final class AllImpl[P, Q, F] private (implicit
     protected val pathError: PathMatchingError[P],
     protected val queryError: ParamMatchingError[Q],
     protected val fragmentError: FragmentMatchingError[F]
@@ -12,8 +11,7 @@ final class AllImpl[P, Q, F] private (
     with FragmentImpl[F]
 
 object AllImpl {
-  def apply[P, Q, F](
-      implicit
+  def apply[P, Q, F](implicit
       pathError: PathMatchingError[P],
       queryError: ParamMatchingError[Q],
       fragmentError: FragmentMatchingError[F]

--- a/url-dsl/src/main/scala/urldsl/language/FragmentImpl.scala
+++ b/url-dsl/src/main/scala/urldsl/language/FragmentImpl.scala
@@ -6,40 +6,36 @@ import urldsl.vocabulary.{FromString, Printer}
 import scala.reflect.ClassTag
 import scala.language.implicitConversions
 
-/**
-  * This is the analogue of [[PathSegmentImpl]] for the [[Fragment]] trait. It "pre-applies" the error type based on the
+/** This is the analogue of [[PathSegmentImpl]] for the [[Fragment]] trait. It "pre-applies" the error type based on the
   * provided [[FragmentMatchingError]].
   *
-  * @tparam E type of the "pre-applied" errors
+  * @tparam E
+  *   type of the "pre-applied" errors
   */
 trait FragmentImpl[E] {
 
   /** implementation of [[FragmentMatchingError]] for generating relevant matching errors. */
   implicit protected val fragmentError: FragmentMatchingError[E]
 
-  /**
-    * Returns a [[Fragment]] matching an element of type T.
-    * If the fragment is missing, it fails with a missing fragment error.
+  /** Returns a [[Fragment]] matching an element of type T. If the fragment is missing, it fails with a missing fragment
+    * error.
     */
   final def fragment[T](implicit fromString: FromString[T, E], printer: Printer[T]): Fragment[T, E] =
     Fragment.fragment[T, E]
 
-  /**
-    * Returns a [[Fragment]] matching an element of type T.
-    * If the fragment is missing, it succeeds with None.
+  /** Returns a [[Fragment]] matching an element of type T. If the fragment is missing, it succeeds with None.
     */
   final def maybeFragment[T](implicit fromString: FromString[T, E], printer: Printer[T]): Fragment[Option[T], E] =
     Fragment.maybeFragment[T, E]
 
-  /**
-    * Returns a [[Fragment]] imposing that the URL does not contain any fragment.
+  /** Returns a [[Fragment]] imposing that the URL does not contain any fragment.
     *
     * Note that a URL ending with "#" is considered having no fragment.
     */
   final def emptyFragment: Fragment[Unit, E] = Fragment.empty
 
-  implicit final def asFragment[T](t: T)(
-      implicit fromString: FromString[T, E],
+  implicit final def asFragment[T](t: T)(implicit
+      fromString: FromString[T, E],
       printer: Printer[T],
       classTag: ClassTag[T]
   ): Fragment[Unit, E] = Fragment.asFragment(t)

--- a/url-dsl/src/main/scala/urldsl/language/PathQueryFragmentRepr.scala
+++ b/url-dsl/src/main/scala/urldsl/language/PathQueryFragmentRepr.scala
@@ -11,7 +11,14 @@ import urldsl.vocabulary.{
   Segment
 }
 
-final class PathQueryFragmentRepr[PathType, +PathError, ParamsType, +ParamsError, FragmentType, +FragmentError] private[language] (
+final class PathQueryFragmentRepr[
+    PathType,
+    +PathError,
+    ParamsType,
+    +ParamsError,
+    FragmentType,
+    +FragmentError
+] private[language] (
     pathSegment: PathSegment[PathType, PathError],
     queryParams: QueryParameters[ParamsType, ParamsError],
     fragment: Fragment[FragmentType, FragmentError]
@@ -73,8 +80,8 @@ final class PathQueryFragmentRepr[PathType, +PathError, ParamsType, +ParamsError
   }
 
   /** If this instance actually only bear path information, retrieves that information only. */
-  def pathOnly(
-      implicit ev1: Unit =:= ParamsType,
+  def pathOnly(implicit
+      ev1: Unit =:= ParamsType,
       ev2: Unit =:= FragmentType
   ): UrlPart[PathType, PathQueryFragmentError[PathError, ParamsError, FragmentError]] =
     UrlPart.factory(
@@ -83,8 +90,8 @@ final class PathQueryFragmentRepr[PathType, +PathError, ParamsType, +ParamsError
     )
 
   /** If this instance actually only bear query information, retrieves that information only. */
-  def queryOnly(
-      implicit ev1: Unit =:= PathType,
+  def queryOnly(implicit
+      ev1: Unit =:= PathType,
       ev2: Unit =:= FragmentType
   ): UrlPart[ParamsType, PathQueryFragmentError[PathError, ParamsError, FragmentError]] =
     UrlPart.factory(
@@ -93,8 +100,8 @@ final class PathQueryFragmentRepr[PathType, +PathError, ParamsType, +ParamsError
     )
 
   /** If this instance actually only bear fragment information, retrieves that information only. */
-  def fragmentOnly(
-      implicit ev1: Unit =:= ParamsType,
+  def fragmentOnly(implicit
+      ev1: Unit =:= ParamsType,
       ev2: Unit =:= PathType
   ): UrlPart[FragmentType, PathQueryFragmentError[PathError, ParamsError, FragmentError]] =
     UrlPart.factory(

--- a/url-dsl/src/main/scala/urldsl/language/PathSegmentImpl.scala
+++ b/url-dsl/src/main/scala/urldsl/language/PathSegmentImpl.scala
@@ -5,12 +5,10 @@ import urldsl.vocabulary.{FromString, Printer, Segment}
 
 import scala.language.implicitConversions
 
-/**
-  * Using the pre-defined path segments in [[PathSegment]] can be cumbersome if you have to constantly specify the error
+/** Using the pre-defined path segments in [[PathSegment]] can be cumbersome if you have to constantly specify the error
   * type A, for example in the [[PathSegment.segment]] or [[PathSegment.root]] methods. Therefore, you can invoke an
-  * implementation of this class and import its members instead.
-  * We don't redefine [[PathSegment.intSegment]] and [[PathSegment.stringSegment]] since they can be easily and
-  * conveniently invoked using the `segment` method below.
+  * implementation of this class and import its members instead. We don't redefine [[PathSegment.intSegment]] and
+  * [[PathSegment.stringSegment]] since they can be easily and conveniently invoked using the `segment` method below.
   *
   * @example
   *   {{{
@@ -22,7 +20,8 @@ import scala.language.implicitConversions
   *           [[PathSegment]] companion object)
   *   }}}
   *
-  * @tparam A type of error.
+  * @tparam A
+  *   type of error.
   */
 trait PathSegmentImpl[A] {
 
@@ -43,8 +42,8 @@ trait PathSegmentImpl[A] {
   /* I think this should not be necessary but the compiler has difficulties finding the correct error due to covariance */
   implicit def unaryPathSegment[T](
       t: T
-  )(
-      implicit fromString: FromString[T, A],
+  )(implicit
+      fromString: FromString[T, A],
       printer: Printer[T]
   ): PathSegment[Unit, A] =
     PathSegment.simplePathSegment(

--- a/url-dsl/src/main/scala/urldsl/language/PathSegmentWithQueryParams.scala
+++ b/url-dsl/src/main/scala/urldsl/language/PathSegmentWithQueryParams.scala
@@ -74,8 +74,7 @@ final class PathSegmentWithQueryParams[PathType, +PathError, ParamsType, +Params
     pathSegment.createPath(path, generator) ++ "?" ++ queryParams.createParamsString(params, generator)
 
   def &[OtherParamsType, ParamsError1 >: ParamsError](otherParams: QueryParameters[OtherParamsType, ParamsError1])(
-      implicit
-      c: Composition[ParamsType, OtherParamsType]
+      implicit c: Composition[ParamsType, OtherParamsType]
   ): PathSegmentWithQueryParams[PathType, PathError, c.Composed, ParamsError1] =
     new PathSegmentWithQueryParams[PathType, PathError, c.Composed, ParamsError1](
       pathSegment,

--- a/url-dsl/src/main/scala/urldsl/language/QueryParameters.scala
+++ b/url-dsl/src/main/scala/urldsl/language/QueryParameters.scala
@@ -9,19 +9,19 @@ trait QueryParameters[Q, +A] extends UrlPart[Q, A] {
 
   import QueryParameters._
 
-  /**
-    * Tries to match the map of [[urldsl.vocabulary.Param]]s to create an instance of `Q`.
-    * If it can not, it returns an error indicating the reason of the failure.
-    * If it could, it returns the value of `Q`, as well as the list of unused parameters.
+  /** Tries to match the map of [[urldsl.vocabulary.Param]]s to create an instance of `Q`. If it can not, it returns an
+    * error indicating the reason of the failure. If it could, it returns the value of `Q`, as well as the list of
+    * unused parameters.
     *
     * @example
-    *           For example, if you try to match a param "name" as String and "age" as Int, calling matchParams on
-    *           Map("name" -> Param(List("Alice")), "age" -> Param(List("24"), "year" -> Param(List("2020")))
-    *           will return
-    *           Right(ParamMatchOutput(("Alice", 24), Map("year" -> Param(List("2020")))
+    *   For example, if you try to match a param "name" as String and "age" as Int, calling matchParams on Map("name" ->
+    *   Param(List("Alice")), "age" -> Param(List("24"), "year" -> Param(List("2020"))) will return
+    *   Right(ParamMatchOutput(("Alice", 24), Map("year" -> Param(List("2020")))
     *
-    * @param params The map of [[urldsl.vocabulary.Param]] to match this path segment again.
-    * @return The "de-serialized" element with unused parameters, if successful.
+    * @param params
+    *   The map of [[urldsl.vocabulary.Param]] to match this path segment again.
+    * @return
+    *   The "de-serialized" element with unused parameters, if successful.
     */
   def matchParams(params: Map[String, Param]): Either[A, ParamMatchOutput[Q]]
 
@@ -34,8 +34,7 @@ trait QueryParameters[Q, +A] extends UrlPart[Q, A] {
   def matchQueryString(queryString: String, decoder: UrlStringDecoder = UrlStringDecoder.defaultDecoder): Either[A, Q] =
     matchParams(decoder.decodeParams(queryString)).map(_.output)
 
-  /**
-    * Generate a map of parameters representing the argument `q`.
+  /** Generate a map of parameters representing the argument `q`.
     *
     * `matchParams` and `createParams` should be (functional) inverse of each other. That is,
     * `this.matchParams(this.createParams(q)) == Right(ParamMathOutput(q, Map()))` (this property is called
@@ -43,15 +42,13 @@ trait QueryParameters[Q, +A] extends UrlPart[Q, A] {
     */
   def createParams(q: Q): Map[String, Param]
 
-  /**
-    * Generates a Map of parameters representing the argument `q`. The keys are not encoded, but the values are lists of
+  /** Generates a Map of parameters representing the argument `q`. The keys are not encoded, but the values are lists of
     * encoded strings.
     */
   final def createParamsMap(q: Q, encoder: UrlStringGenerator = UrlStringGenerator.default): Map[String, List[String]] =
     encoder.makeParamsMap(createParams(q))
 
-  /**
-    * Generates the query string representing the argument `q`. This String can be used to be part of a URL.
+  /** Generates the query string representing the argument `q`. This String can be used to be part of a URL.
     */
   final def createParamsString(q: Q, encoder: UrlStringGenerator = UrlStringGenerator.default): String =
     encoder.makeParams(createParams(q))
@@ -59,15 +56,16 @@ trait QueryParameters[Q, +A] extends UrlPart[Q, A] {
   final def createPart(q: Q, encoder: UrlStringGenerator = UrlStringGenerator.default): String =
     createParamsString(q, encoder)
 
-  /**
-    * Adds `that` QueryParameters to `this` one, "tupling" the returned type with the implicit [[Composition]]
+  /** Adds `that` QueryParameters to `this` one, "tupling" the returned type with the implicit [[Composition]]
     *
     * The matching and writing of strings is functionally commutative under `&`, but the returned type `Q` is not. So,
     * if you have two parameters, one matching an Int and the other one a String, depending on the order in which `&` is
     * called, you can end up with "Q = (Int, String)" or "Q = (String, Int)". This property is called
     * "QuasiCommutativity" in the tests.
     */
-  final def &[R, A1 >: A](that: QueryParameters[R, A1])(implicit c: Composition[Q, R]): QueryParameters[c.Composed, A1] =
+  final def &[R, A1 >: A](that: QueryParameters[R, A1])(implicit
+      c: Composition[Q, R]
+  ): QueryParameters[c.Composed, A1] =
     factory[c.Composed, A1](
       (params: Map[String, Param]) =>
         for {
@@ -82,8 +80,7 @@ trait QueryParameters[Q, +A] extends UrlPart[Q, A] {
       }
     )
 
-  /**
-    * When these query parameters return an error, transform it to None instead.
+  /** When these query parameters return an error, transform it to None instead.
     *
     * This should be used to represent (possibly) missing parameters.
     */
@@ -96,21 +93,21 @@ trait QueryParameters[Q, +A] extends UrlPart[Q, A] {
     _.map(createParams).getOrElse(Map())
   )
 
-  /**
-    * Adds an extra satisfying criteria to the output of this [[QueryParameters]].
-    * If the output satisfies the given `predicate`, then it is left unchanged. Otherwise, it returns the given
-    * `error`.
+  /** Adds an extra satisfying criteria to the output of this [[QueryParameters]]. If the output satisfies the given
+    * `predicate`, then it is left unchanged. Otherwise, it returns the given `error`.
     *
-    * Note that it doesn't check that arguments given to `createParams` satisfy this predicate
-    * // todo[behaviour]: should that change?
+    * Note that it doesn't check that arguments given to `createParams` satisfy this predicate // todo[behaviour]:
+    * should that change?
     *
-    * @example {{{
-    *           param[Int]("age").filter(_ >= 0, (params: Map[String, Param]) => someError(params))
-    * }}}
+    * @example
+    *   {{{ param[Int]("age").filter(_ >= 0, (params: Map[String, Param]) => someError(params)) }}}
     *
-    * @param predicate the additional predicate that the output must satisfy
-    * @param error     the generated error in case it does not satisfy it
-    * @return          a new [[QueryParameters]] instance with the same types
+    * @param predicate
+    *   the additional predicate that the output must satisfy
+    * @param error
+    *   the generated error in case it does not satisfy it
+    * @return
+    *   a new [[QueryParameters]] instance with the same types
     */
   final def filter[A1 >: A](predicate: Q => Boolean, error: Map[String, Param] => A1): QueryParameters[Q, A1] = factory(
     (params: Map[String, Param]) =>
@@ -126,8 +123,7 @@ trait QueryParameters[Q, +A] extends UrlPart[Q, A] {
     this.asInstanceOf[QueryParameters[Q, DummyError]].filter(predicate, _ => DummyError.dummyError)
   }
 
-  /**
-    * Casts this [[QueryParameters]] to the new type R. Note that the [[urldsl.vocabulary.Codec]] must be an
+  /** Casts this [[QueryParameters]] to the new type R. Note that the [[urldsl.vocabulary.Codec]] must be an
     * exception-free bijection between Q and R.
     */
   final def as[R](implicit codec: Codec[Q, R]): QueryParameters[R, A] = factory(
@@ -135,8 +131,7 @@ trait QueryParameters[Q, +A] extends UrlPart[Q, A] {
     (codec.rightToLeft _).andThen(createParams)
   )
 
-  /**
-    * Associates this [[QueryParameters]] with the given [[Fragment]] in order to match raw urls satisfying both
+  /** Associates this [[QueryParameters]] with the given [[Fragment]] in order to match raw urls satisfying both
     * conditions, and returning the outputs from both.
     *
     * The path part of the url will be *ignored* (and will return Unit).
@@ -179,7 +174,7 @@ object QueryParameters {
         .map(_.map(ParamMatchOutput(_, params - paramName))) // consumes that param
         .getOrElse(onParameterNotFound(params)),
     creating.andThen(paramName -> _).andThen(Map(_))
-)
+  )
 
   final def simpleQueryParam[Q, A](
       paramName: String,
@@ -191,12 +186,12 @@ object QueryParameters {
       matching,
       creating,
       onParameterNotFound = _ => Left(paramMatchingError.missingParameterError(paramName))
-  )
+    )
 
   final def param[Q, A](
       paramName: String
-  )(
-      implicit fromString: FromString[Q, A],
+  )(implicit
+      fromString: FromString[Q, A],
       printer: Printer[Q],
       paramMatchingError: ParamMatchingError[A]
   ): QueryParameters[Q, A] =
@@ -211,8 +206,8 @@ object QueryParameters {
 
   final def listParam[Q, A](
       paramName: String
-  )(
-      implicit fromString: FromString[Q, A],
+  )(implicit
+      fromString: FromString[Q, A],
       printer: Printer[Q],
       paramMatchingError: ParamMatchingError[A]
   ): QueryParameters[List[Q], A] =

--- a/url-dsl/src/main/scala/urldsl/language/UrlPart.scala
+++ b/url-dsl/src/main/scala/urldsl/language/UrlPart.scala
@@ -2,10 +2,9 @@ package urldsl.language
 
 import urldsl.url.{UrlStringGenerator, UrlStringParserGenerator}
 
-/**
-  * A [[UrlPart]] represents a part of (or the entire) URL and is able to extract some information out of it.
-  * When it succeeds to extract information, it returns an element of type T (wrapped in a [[Right]]). When it fails
-  * to extract such information, it returns an error type E (wrapped in a [[Left]].
+/** A [[UrlPart]] represents a part of (or the entire) URL and is able to extract some information out of it. When it
+  * succeeds to extract information, it returns an element of type T (wrapped in a [[Right]]). When it fails to extract
+  * such information, it returns an error type E (wrapped in a [[Left]].
   *
   * A [[UrlPart]] is also able to generate its corresponding part of the URL by ingesting an element of type T. When
   * doing that, it outputs a String (whose semantic may vary depending on the type of [[UrlPart]] you are dealing with).
@@ -41,10 +40,9 @@ object UrlPart {
     def createPart(t: T, encoder: UrlStringGenerator): String = generator(t, encoder)
   }
 
-  /**
-    * Type alias when you don't care about what kind of error is issued.
-    * [[Any]] can seem weird, but it has to be understood as "since it can fail with anything, I won't be able to do
-    * anything with the error, which means that I can only check whether it failed or not".
+  /** Type alias when you don't care about what kind of error is issued. [[Any]] can seem weird, but it has to be
+    * understood as "since it can fail with anything, I won't be able to do anything with the error, which means that I
+    * can only check whether it failed or not".
     */
   type SimpleUrlPart[T] = UrlPart[T, Any]
 

--- a/url-dsl/src/main/scala/urldsl/url/UrlStringParser.scala
+++ b/url-dsl/src/main/scala/urldsl/url/UrlStringParser.scala
@@ -15,7 +15,7 @@ trait UrlStringParser extends UrlStringDecoder {
   /** Returns the raw content of the fragment (sometimes called ref), or None if there is no fragment */
   def maybeFragment: Option[String]
 
-  /** Alias for [[maybeFragment]].  */
+  /** Alias for [[maybeFragment]]. */
   final def maybeRef: Option[String] = maybeFragment
 
   final def segments: List[Segment] = decodePath(path)

--- a/url-dsl/src/main/scala/urldsl/vocabulary/Codec.scala
+++ b/url-dsl/src/main/scala/urldsl/vocabulary/Codec.scala
@@ -1,7 +1,6 @@
 package urldsl.vocabulary
 
-/**
-  * Represents a bijection between `Left` and `Right`.
+/** Represents a bijection between `Left` and `Right`.
   *
   * This bijection is supposed to be "exception-free", and be an actual bijection.
   */
@@ -26,8 +25,7 @@ object Codec {
     def rightToLeft(right: U): T = uToT(right)
   }
 
-  implicit def composeCodecs[Left, Middle, Right](
-      implicit
+  implicit def composeCodecs[Left, Middle, Right](implicit
       leftCodec: Codec[Left, Middle],
       rightCodec: Codec[Middle, Right]
   ): Codec[Left, Right] = leftCodec ++ rightCodec

--- a/url-dsl/src/main/scala/urldsl/vocabulary/FromString.scala
+++ b/url-dsl/src/main/scala/urldsl/vocabulary/FromString.scala
@@ -19,26 +19,24 @@ object FromString extends FromStringWithNumeric {
   def factory[T, A](read: String => Either[A, T]): FromString[T, A] = (str: String) => read(str)
 
   implicit def stringFromString[A]: FromString[String, A] = factory(Right(_))
-  implicit def intFromString[A](implicit fromThrowable: ErrorFromThrowable[A]): FromString[Int, A] = factory(
-    s =>
-      Try(s.toInt) match {
-        case Success(int)       => Right(int)
-        case Failure(exception) => Left(fromThrowable.fromThrowable(exception))
-      }
+  implicit def intFromString[A](implicit fromThrowable: ErrorFromThrowable[A]): FromString[Int, A] = factory(s =>
+    Try(s.toInt) match {
+      case Success(int)       => Right(int)
+      case Failure(exception) => Left(fromThrowable.fromThrowable(exception))
+    }
   )
-  implicit def doubleFromString[A](implicit fromThrowable: ErrorFromThrowable[A]): FromString[Double, A] = factory(
-    s =>
-      Try(s.toDouble) match {
-        case Success(double)    => Right(double)
-        case Failure(exception) => Left(fromThrowable.fromThrowable(exception))
-      }
+  implicit def doubleFromString[A](implicit fromThrowable: ErrorFromThrowable[A]): FromString[Double, A] = factory(s =>
+    Try(s.toDouble) match {
+      case Success(double)    => Right(double)
+      case Failure(exception) => Left(fromThrowable.fromThrowable(exception))
+    }
   )
-  implicit def booleanFromString[A](implicit fromThrowable: ErrorFromThrowable[A]): FromString[Boolean, A] = factory(
-    s =>
+  implicit def booleanFromString[A](implicit fromThrowable: ErrorFromThrowable[A]): FromString[Boolean, A] =
+    factory(s =>
       Try(s.toBoolean) match {
         case Success(bool) => Right(bool)
         case Failure(_)    => Left(fromThrowable.fromThrowable(new Exception(s"$s is not a Boolean")))
       }
-  )
+    )
 
 }

--- a/url-dsl/src/main/scala/urldsl/vocabulary/MaybeFragment.scala
+++ b/url-dsl/src/main/scala/urldsl/vocabulary/MaybeFragment.scala
@@ -1,7 +1,6 @@
 package urldsl.vocabulary
 
-/**
-  * Wrapper around the raw fragment part of the URL.
+/** Wrapper around the raw fragment part of the URL.
   *
   * None when the URL does not contain any fragment.
   */

--- a/url-dsl/src/main/scala/urldsl/vocabulary/Param.scala
+++ b/url-dsl/src/main/scala/urldsl/vocabulary/Param.scala
@@ -14,7 +14,7 @@ object Param {
       .map(_.split("=").toList)
       .toList
       .collect {
-        case first :: Nil if first.nonEmpty => first -> ""
+        case first :: Nil if first.nonEmpty           => first -> ""
         case first :: second :: Nil if first.nonEmpty => first -> second
       }
       .groupBy(_._1)

--- a/url-dsl/src/main/scala/urldsl/vocabulary/PathMatchOutput.scala
+++ b/url-dsl/src/main/scala/urldsl/vocabulary/PathMatchOutput.scala
@@ -1,12 +1,13 @@
 package urldsl.vocabulary
 
-/**
-  * Returned type of matching segments against a [[urldsl.language.PathSegment]].
+/** Returned type of matching segments against a [[urldsl.language.PathSegment]].
   *
   * This is used to avoid returning an ugly tuple.
   *
-  * @param output the de-serialized element from the matching
-  * @param unusedSegments the segments that were not used to generate the output
+  * @param output
+  *   the de-serialized element from the matching
+  * @param unusedSegments
+  *   the segments that were not used to generate the output
   */
 final case class PathMatchOutput[T](output: T, unusedSegments: List[Segment]) {
   def map[U](f: T => U): PathMatchOutput[U] = PathMatchOutput(f(output), unusedSegments)

--- a/url-dsl/src/main/scala/urldsl/vocabulary/PathQueryFragmentMatching.scala
+++ b/url-dsl/src/main/scala/urldsl/vocabulary/PathQueryFragmentMatching.scala
@@ -2,8 +2,8 @@ package urldsl.vocabulary
 
 final case class PathQueryFragmentMatching[P, Q, F](path: P, query: Q, fragment: F) {
 
-  def extractInfo[P1, Q1](
-      implicit ev1: P =:= PathMatchOutput[P1],
+  def extractInfo[P1, Q1](implicit
+      ev1: P =:= PathMatchOutput[P1],
       ev2: Q =:= ParamMatchOutput[Q1]
   ): PathQueryFragmentMatching[P1, Q1, F] =
     PathQueryFragmentMatching(ev1(path).output, ev2(query).output, fragment)

--- a/url-dsl/src/test/scala-3/urldsl/vocabulary/CodecSpecFor3.scala
+++ b/url-dsl/src/test/scala-3/urldsl/vocabulary/CodecSpecFor3.scala
@@ -40,4 +40,3 @@ final class CodecSpecFor3 extends munit.FunSuite {
   }
 
 }
-

--- a/url-dsl/src/test/scala-3/urldsl/vocabulary/FromString213Spec.scala
+++ b/url-dsl/src/test/scala-3/urldsl/vocabulary/FromString213Spec.scala
@@ -6,18 +6,18 @@ import urldsl.errors.DummyError
 
 final class FromString3Spec extends AnyFlatSpec with Matchers {
 
-    def getTheT[T](s: String)(using fromString: FromString[T, DummyError]): Either[DummyError, T] = fromString(s)
+  def getTheT[T](s: String)(using fromString: FromString[T, DummyError]): Either[DummyError, T] = fromString(s)
 
-    "The FromString implicit for Numeric" should "be correctly called" in {
+  "The FromString implicit for Numeric" should "be correctly called" in {
 
-        getTheT[BigInt]("123456789012345678901234567890") should be(
-            Right(BigInt("123456789012345678901234567890"))
-        )
+    getTheT[BigInt]("123456789012345678901234567890") should be(
+      Right(BigInt("123456789012345678901234567890"))
+    )
 
-        getTheT[BigDecimal]("123.4") should be (Right(BigDecimal(123.4)))
+    getTheT[BigDecimal]("123.4") should be(Right(BigDecimal(123.4)))
 
-        getTheT[BigInt]("Hi") should be (Left(DummyError.dummyError))
+    getTheT[BigInt]("Hi") should be(Left(DummyError.dummyError))
 
-    }
+  }
 
 }

--- a/url-dsl/src/test/scala/urldsl/examples/CombinedExamples.scala
+++ b/url-dsl/src/test/scala/urldsl/examples/CombinedExamples.scala
@@ -4,16 +4,15 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import urldsl.vocabulary.{PathQueryFragmentMatching, UrlMatching}
 
-/**
-  * In this class, we showcase examples of combining:
-  * - [[urldsl.language.PathSegment]]
-  * - [[urldsl.language.QueryParameters]], and
-  * - [[urldsl.language.Fragment]].
+/** In this class, we showcase examples of combining:
+  *   - [[urldsl.language.PathSegment]]
+  *   - [[urldsl.language.QueryParameters]], and
+  *   - [[urldsl.language.Fragment]].
   *
   * Unlike other examples, we will use the [[urldsl.errors.DummyError]] implementations.
   *
-  * When you combine these, you will end up manipulating objects that can seem nasty. However, the user experience
-  * of code that you actually have to write should stay pretty.
+  * When you combine these, you will end up manipulating objects that can seem nasty. However, the user experience of
+  * code that you actually have to write should stay pretty.
   */
 //noinspection TypeAnnotation
 final class CombinedExamples extends AnyFlatSpec with Matchers {
@@ -42,10 +41,8 @@ final class CombinedExamples extends AnyFlatSpec with Matchers {
       Right(PathQueryFragmentMatching((), ("stuff", List(2, 3)), "the-ref"))
     )
 
-    /**
-      * Finally, we can combine everything.
-      * Note that we first have to combine a [[urldsl.language.PathSegment]] and the [[urldsl.language.QueryParameters]]
-      * and then add the [[urldsl.language.Fragment]].
+    /** Finally, we can combine everything. Note that we first have to combine a [[urldsl.language.PathSegment]] and the
+      * [[urldsl.language.QueryParameters]] and then add the [[urldsl.language.Fragment]].
       */
     (pathPart ? queryPart).withFragment(fragmentPart).matchRawUrl(sampleUrl) should be(
       Right(PathQueryFragmentMatching(23, ("stuff", List(2, 3)), "the-ref"))

--- a/url-dsl/src/test/scala/urldsl/examples/FragmentExamples.scala
+++ b/url-dsl/src/test/scala/urldsl/examples/FragmentExamples.scala
@@ -5,8 +5,7 @@ import org.scalatest.matchers.should.Matchers
 import urldsl.errors.SimpleFragmentMatchingError
 import urldsl.language.Fragment
 
-/**
-  * This class exposes some example of usage of the [[urldsl.language.Fragment]] class.
+/** This class exposes some example of usage of the [[urldsl.language.Fragment]] class.
   *
   * The `sampleUrl` and `sampleUrlWithoutFragment` used throughout this example class is defined in the
   * [[urldsl.examples]] package object.
@@ -17,19 +16,17 @@ final class FragmentExamples extends AnyFlatSpec with Matchers {
 
   "Some matching examples" should "work" in {
 
-    /**
-      * We can ask that the fragment should be some specific value.
-      * Note that unlike [[urldsl.language.PathSegment]], there is no "root" element and hence, we need to cast an
-      * element by hand into a [[urldsl.language.Fragment]]. There is still an implicit conversion, but it will be
-      * called only in a place where you ask for a [[urldsl.language.Fragment]] (see below)
+    /** We can ask that the fragment should be some specific value. Note that unlike [[urldsl.language.PathSegment]],
+      * there is no "root" element and hence, we need to cast an element by hand into a [[urldsl.language.Fragment]].
+      * There is still an implicit conversion, but it will be called only in a place where you ask for a
+      * [[urldsl.language.Fragment]] (see below)
       */
     asFragment("the-ref").matchRawUrl(sampleUrl) should be(Right(()))
 
     /** We can also ask that the fragment is present and of the desired type. */
     fragment[String].matchRawUrl(sampleUrl) should be(Right("the-ref"))
 
-    /**
-      * We can require that the fragment is not there (which would also be the case if the url ends with #!)
+    /** We can require that the fragment is not there (which would also be the case if the url ends with #!)
       */
     emptyFragment.matchRawUrl(sampleUrl) should be(Left(SimpleFragmentMatchingError.FragmentWasPresent("the-ref")))
     emptyFragment.matchRawUrl(sampleUrlWithoutFragment) should be(Right(()))

--- a/url-dsl/src/test/scala/urldsl/examples/PathSegmentExamples.scala
+++ b/url-dsl/src/test/scala/urldsl/examples/PathSegmentExamples.scala
@@ -5,8 +5,7 @@ import org.scalatest.matchers.should.Matchers
 import urldsl.errors.SimplePathMatchingError
 import urldsl.vocabulary.{Codec, Segment}
 
-/**
-  * This class exposes some example of usage of the [[urldsl.language.PathSegment]] class.
+/** This class exposes some example of usage of the [[urldsl.language.PathSegment]] class.
   *
   * The `sampleUrl` used throughout this example class is defined in the [[urldsl.examples]] package object.
   */
@@ -20,14 +19,12 @@ final class PathSegmentExamples extends AnyFlatSpec with Matchers {
     /** `root` is a "dummy" matcher which matches anything. It returns [[Unit]] when matching. */
     root.matchRawUrl(sampleUrl) should be(Right(()))
 
-    /**
-      * Appending a specific segment value to the root in order to match the first segment.
-      * It returns Unit when matching, since we assume that the information is already known (it's "foo").
+    /** Appending a specific segment value to the root in order to match the first segment. It returns Unit when
+      * matching, since we assume that the information is already known (it's "foo").
       */
     (root / "foo").matchRawUrl(sampleUrl) should be(Right(()))
 
-    /**
-      * Appending a [[String]] segmennt in order to retrieve the information contained in the first segment.
+    /** Appending a [[String]] segmennt in order to retrieve the information contained in the first segment.
       */
     (root / segment[String]).matchRawUrl(sampleUrl) should be(Right("foo"))
 
@@ -44,13 +41,12 @@ final class PathSegmentExamples extends AnyFlatSpec with Matchers {
       Right(("foo", 23, true))
     )
 
-    /**
-      * You can compose things the way you like, "pre-computing" segments.
+    /** You can compose things the way you like, "pre-computing" segments.
       *
-      * The `/` operator is *associative*, which means that the "place where you put parenthesis" doesn't matter. In
-      * the same way that (3+4)+5 = 3+(4+5), you have that `(s1 / s2) / s3 = s1 / (s2 / s3)`. Note that they won't be
-      * equal as Scala objects, but they will be for any (relevant) observable behaviour. (Technical note: it's not
-      * entirely true if you go crazy in tupling things.)
+      * The `/` operator is *associative*, which means that the "place where you put parenthesis" doesn't matter. In the
+      * same way that (3+4)+5 = 3+(4+5), you have that `(s1 / s2) / s3 = s1 / (s2 / s3)`. Note that they won't be equal
+      * as Scala objects, but they will be for any (relevant) observable behaviour. (Technical note: it's not entirely
+      * true if you go crazy in tupling things.)
       */
     val s1 = segment[String]
     val s2 = segment[Int]
@@ -60,7 +56,9 @@ final class PathSegmentExamples extends AnyFlatSpec with Matchers {
     /** You can also "group" several segments into a more meaningful class than a pair or a triplet. */
     case class Stuff(str: String, j: Int)
 
-    (s1 / s2).as((t: (String, Int)) => Stuff(t._1, t._2), (s: Stuff) => s match { case Stuff(str, j) => (str, j) }).matchRawUrl(sampleUrl) should be(
+    (s1 / s2)
+      .as((t: (String, Int)) => Stuff(t._1, t._2), (s: Stuff) => s match { case Stuff(str, j) => (str, j) })
+      .matchRawUrl(sampleUrl) should be(
       Right(Stuff("foo", 23))
     )
 
@@ -80,21 +78,18 @@ final class PathSegmentExamples extends AnyFlatSpec with Matchers {
       )
     )
 
-    /**
-      * As you probably noticed, [[urldsl.language.PathSegment]] are immutable objects and hence, can be reused freely.
+    /** As you probably noticed, [[urldsl.language.PathSegment]] are immutable objects and hence, can be reused freely.
       */
     (s1 / s1).matchRawUrl(sampleUrl) should be(Right("foo", "23"))
 
-    /**
-      * You also have the ability to compose [[urldsl.language.PathSegment]] "horizontally", by "branching" several
+    /** You also have the ability to compose [[urldsl.language.PathSegment]] "horizontally", by "branching" several
       * possibilities
       */
     (root / (segment[Int] || segment[String])).matchRawUrl(sampleUrl) should be(Right(Right("foo")))
 
-    /**
-      * The [[urldsl.language.PathSegment]] trait is also very general, and while part of its power comes from its
-      * great "composability", it also comes from its ability to make quite generic things.
-      * One example is imposing that the path has ended.
+    /** The [[urldsl.language.PathSegment]] trait is also very general, and while part of its power comes from its great
+      * "composability", it also comes from its ability to make quite generic things. One example is imposing that the
+      * path has ended.
       */
     (root / "foo" / 23 / true / endOfSegments).matchRawUrl(sampleUrl) should be(Right(()))
     (root / "foo" / endOfSegments).matchRawUrl(sampleUrl) should be(
@@ -133,16 +128,17 @@ final class PathSegmentExamples extends AnyFlatSpec with Matchers {
     )
 
     /** Flattening of int-tuple segment with [[app.tulz.tuplez.Composition]] */
-    (root / segment[String] / segment[(Int, Int)] / "hey").matchPath("hello/22-33/hey") should be(Right("hello", 22, 33))
+    (root / segment[String] / segment[(Int, Int)] / "hey").matchPath("hello/22-33/hey") should be(
+      Right("hello", 22, 33)
+    )
 
   }
 
   "Some generating examples" should "work" in {
 
-    /**
-      * You can also use [[urldsl.language.PathSegment]]s for generating paths.
-      * Note that the strength of urldsl is that the `createPart` method is typesafe and knows what the path expects
-      * as information in order to generate the path string.
+    /** You can also use [[urldsl.language.PathSegment]]s for generating paths. Note that the strength of urldsl is that
+      * the `createPart` method is typesafe and knows what the path expects as information in order to generate the path
+      * string.
       */
     (root / segment[String] / segment[Int] / "hey").createPart(("hello", 22)) should be("hello/22/hey")
 

--- a/url-dsl/src/test/scala/urldsl/examples/QueryParamsExamples.scala
+++ b/url-dsl/src/test/scala/urldsl/examples/QueryParamsExamples.scala
@@ -5,8 +5,7 @@ import org.scalatest.matchers.should.Matchers
 import urldsl.errors.SimpleParamMatchingError
 import urldsl.language.QueryParameters
 
-/**
-  * This class exposes some example of usage of the [[urldsl.language.QueryParameters]] class.
+/** This class exposes some example of usage of the [[urldsl.language.QueryParameters]] class.
   *
   * The `sampleUrl` used throughout this example class is defined in the [[urldsl.examples]] package object.
   */
@@ -16,9 +15,8 @@ final class QueryParamsExamples extends AnyFlatSpec with Matchers {
 
   "Some matching examples" should "work" in {
 
-    /**
-      * You can match a simple information from the query parameter.
-      * This param will look for the parameter "bar" in the query string.
+    /** You can match a simple information from the query parameter. This param will look for the parameter "bar" in the
+      * query string.
       */
     param[String]("bar").matchRawUrl(sampleUrl) should be(Right("stuff"))
 
@@ -34,10 +32,8 @@ final class QueryParamsExamples extends AnyFlatSpec with Matchers {
     /** Parameter encoding a tuple */
     param[(Int, Int)]("tuple").matchRawUrl(sampleUrl) should be(Right((11, 22)))
 
-    /**
-      * Sometimes parameters are actually a list of parameters with the same key. You can read this as well.
-      * Note that we sort the list for the check, since the actual order is somewhat unpredictable (although
-      * deterministic).
+    /** Sometimes parameters are actually a list of parameters with the same key. You can read this as well. Note that
+      * we sort the list for the check, since the actual order is somewhat unpredictable (although deterministic).
       */
     listParam[Int]("other").matchRawUrl(sampleUrl).map(_.sorted) should be(Right(List(2, 3)))
 
@@ -57,9 +53,7 @@ final class QueryParamsExamples extends AnyFlatSpec with Matchers {
       Right(("other stuff", "stuff"))
     )
 
-
-    /**
-      * If you want your parameters to match optionally, you can ascribe your [[urldsl.language.QueryParameters]] with
+    /** If you want your parameters to match optionally, you can ascribe your [[urldsl.language.QueryParameters]] with
       * `.?`.
       */
     param[String]("does-not-exist").?.matchRawUrl(sampleUrl) should be(Right(None))
@@ -72,8 +66,7 @@ final class QueryParamsExamples extends AnyFlatSpec with Matchers {
     param[Int]("bar").?.matchRawUrl(sampleUrl) should be(Right(None))
     param[Int]("empty").?.matchRawUrl(sampleUrl) should be(Right(None))
 
-    /**
-      * [[urldsl.language.QueryParameters]] have a filter method allowing to restrict the things it matches.
+    /** [[urldsl.language.QueryParameters]] have a filter method allowing to restrict the things it matches.
       */
     param[String]("bar").filter(_.length > 3, _ => "too short").matchRawUrl(sampleUrl) should be(
       Right(
@@ -87,9 +80,8 @@ final class QueryParamsExamples extends AnyFlatSpec with Matchers {
       )
     )
 
-    /**
-      * The filter and ? combinators can be conveniently combined together.
-      * This is because ? erases any previously encountered error and returns None.
+    /** The filter and ? combinators can be conveniently combined together. This is because ? erases any previously
+      * encountered error and returns None.
       */
     param[String]("bar")
       .filter(_.length > 10, _ => SimpleParamMatchingError.FromThrowable(new RuntimeException("too short")))
@@ -114,8 +106,7 @@ final class QueryParamsExamples extends AnyFlatSpec with Matchers {
       Left(true)
     )
 
-    /**
-      * [[urldsl.language.QueryParameters]] are immutable objects, but used in a single parameter search, this fact is
+    /** [[urldsl.language.QueryParameters]] are immutable objects, but used in a single parameter search, this fact is
       * probably often useless. However, you can re-use it to combine with other parameters.
       */
     val p = param[Int]("other")
@@ -142,7 +133,8 @@ final class QueryParamsExamples extends AnyFlatSpec with Matchers {
     listParam[String]("p1").createPart(Nil) should be("")
 
     /** Flatenning of tuple param */
-    (param[String]("p1") & param[(Int, Int)]("p2") & listParam[String]("p3")).createPart(("hey", 11, 22, List("one", "two"))) should be(
+    (param[String]("p1") & param[(Int, Int)]("p2") & listParam[String]("p3"))
+      .createPart(("hey", 11, 22, List("one", "two"))) should be(
       """p1=hey&p2=11-22&p3=one&p3=two"""
     )
 

--- a/url-dsl/src/test/scala/urldsl/examples/QueryParamsExamples.scala
+++ b/url-dsl/src/test/scala/urldsl/examples/QueryParamsExamples.scala
@@ -41,6 +41,8 @@ final class QueryParamsExamples extends AnyFlatSpec with Matchers {
       */
     listParam[Int]("other").matchRawUrl(sampleUrl).map(_.sorted) should be(Right(List(2, 3)))
 
+    listParam[String]("non-existent").matchRawUrl("http://foo.com/") should be(Right(Nil))
+
     /** You can compose several [[urldsl.language.QueryParameters]] with the `&` operator. */
     (param[String]("bar") & param[String]("babar")).matchRawUrl(sampleUrl) should be(
       Right(("stuff", "other stuff"))
@@ -136,6 +138,8 @@ final class QueryParamsExamples extends AnyFlatSpec with Matchers {
     (param[String]("p1") & listParam[String]("p2")).createPart(("hey", List("one", "two"))) should be(
       """p1=hey&p2=one&p2=two"""
     )
+
+    listParam[String]("p1").createPart(Nil) should be("")
 
     /** Flatenning of tuple param */
     (param[String]("p1") & param[(Int, Int)]("p2") & listParam[String]("p3")).createPart(("hey", 11, 22, List("one", "two"))) should be(

--- a/url-dsl/src/test/scala/urldsl/examples/RouterUseCaseExample.scala
+++ b/url-dsl/src/test/scala/urldsl/examples/RouterUseCaseExample.scala
@@ -5,13 +5,12 @@ import org.scalatest.matchers.should.Matchers
 import urldsl.language.UrlPart.SimpleUrlPart
 import urldsl.vocabulary.{PathQueryFragmentMatching, UrlMatching}
 
-/**
-  * This class shows a possible implementation of a Router. This could be used in a web frontend (using Scala.js) for
+/** This class shows a possible implementation of a Router. This could be used in a web frontend (using Scala.js) for
   * displaying the correct component, or in a web server for triggering the action corresponding to the calling route.
   *
-  * All abstract models are actually instances of [[urldsl.language.UrlPart]], which easily allows to abstract away
-  * the concrete choice the user could make as to how they want to match the URL. In this case, we will simply return
-  * a value based on what was extracted from the route. This value will be an instance of the
+  * All abstract models are actually instances of [[urldsl.language.UrlPart]], which easily allows to abstract away the
+  * concrete choice the user could make as to how they want to match the URL. In this case, we will simply return a
+  * value based on what was extracted from the route. This value will be an instance of the
   * [[urldsl.examples.RouterUseCaseExample#Output]], so that we can easily test that the correct route was called.
   *
   * We use the [[urldsl.errors.DummyError]] implementations since we really want to route correctly, we don't care about
@@ -25,7 +24,9 @@ final class RouterUseCaseExample extends AnyFlatSpec with Matchers {
 
   import urldsl.language.dummyErrorImpl._
 
-  /** Link a [[urldsl.language.UrlPart]] matching some routes, to an action using the information extracted from the route. */
+  /** Link a [[urldsl.language.UrlPart]] matching some routes, to an action using the information extracted from the
+    * route.
+    */
   sealed trait Route[T] {
     def urlPart: SimpleUrlPart[T]
     def action(t: T): Output
@@ -43,14 +44,13 @@ final class RouterUseCaseExample extends AnyFlatSpec with Matchers {
   /** Collection of [[Route]] to be tried in order when calling with a given url. */
   case class Router(routes: List[Route[_]]) {
 
-    /**
-      * Sequentially tries to match the given url with all the routes, and call the action of the first matching.
+    /** Sequentially tries to match the given url with all the routes, and call the action of the first matching.
       */
     def maybeCallAction(rawUrl: String): Option[Output] =
       routes.view
         .map(_(rawUrl))
-        .collectFirst {
-          case Some(output) => output
+        .collectFirst { case Some(output) =>
+          output
         }
 
     /** Same as maybeCallAction with a default output when no match is found. */
@@ -70,14 +70,14 @@ final class RouterUseCaseExample extends AnyFlatSpec with Matchers {
     /** Definition of the router, with in-order defined routes. */
     val theRouter = Router(
       Route(root / endOfSegments)(_ => Output("home")),
-      Route((root / "users").withFragment(fragment[String]).fragmentOnly)(
-        (ref: String) => Output(s"Users view with fragment $ref")
+      Route((root / "users").withFragment(fragment[String]).fragmentOnly)((ref: String) =>
+        Output(s"Users view with fragment $ref")
       ),
       Route(((root / "admin") ? param[String]("username")).withFragment(fragment[String])) {
         case PathQueryFragmentMatching(_, query, f) => Output(s"Admin view for $query at $f")
       },
-      Route((root / "admin") ? param[String]("username")) {
-        case UrlMatching(_, username) => Output(s"Welcome, $username")
+      Route((root / "admin") ? param[String]("username")) { case UrlMatching(_, username) =>
+        Output(s"Welcome, $username")
       },
       Route(root / "admin")(_ => Output("admin view.")),
       Route(notFound)(_ => Output("not found"))

--- a/url-dsl/src/test/scala/urldsl/examples/package.scala
+++ b/url-dsl/src/test/scala/urldsl/examples/package.scala
@@ -5,35 +5,34 @@ import urldsl.vocabulary.{FromString, Printer}
 
 import scala.util.{Failure, Success, Try}
 
-/**
-  * This package shows examples of usage of url-dsl.
+/** This package shows examples of usage of url-dsl.
   *
-  * When using url-dsl, you are free to chose any error adt system that you want. There are two
-  * built-in for you, the [[urldsl.errors.SimplePathMatchingError]] (and siblings) and the
-  * [[urldsl.errors.DummyError]]. We will use the former in these example. The latter being perfect
-  * in cases where you don't care about what caused the error (for example a router) or when you use primarily
-  * url-dsl for generating urls, and not for parsing them.
+  * When using url-dsl, you are free to chose any error adt system that you want. There are two built-in for you, the
+  * [[urldsl.errors.SimplePathMatchingError]] (and siblings) and the [[urldsl.errors.DummyError]]. We will use the
+  * former in these example. The latter being perfect in cases where you don't care about what caused the error (for
+  * example a router) or when you use primarily url-dsl for generating urls, and not for parsing them.
   */
 package object examples {
 
-  val sampleUrl = "http://www.some-domain.be/foo/23/true?bar=stuff&babar=other%20stuff&other=2&other=3&tuple=11-22&empty=&ok=true#the-ref"
+  val sampleUrl =
+    "http://www.some-domain.be/foo/23/true?bar=stuff&babar=other%20stuff&other=2&other=3&tuple=11-22&empty=&ok=true#the-ref"
 
   val sampleUrlWithoutFragment =
     "http://www.some-domain.be/foo/23/true?bar=stuff&babar=other%20stuff&other=2&other=3&ok=true"
 
-  implicit def intTupleFromDashedString[A](
-    implicit fromThrowable: ErrorFromThrowable[A]
+  implicit def intTupleFromDashedString[A](implicit
+      fromThrowable: ErrorFromThrowable[A]
   ): FromString[(Int, Int), A] = FromString.factory { s =>
     Try {
       val parts = s.split("-")
       (parts(0).toInt, parts(1).toInt)
     } match {
       case Success((int1, int2)) => Right((int1, int2))
-      case Failure(exception) => Left(fromThrowable.fromThrowable(exception))
+      case Failure(exception)    => Left(fromThrowable.fromThrowable(exception))
     }
   }
 
-  implicit def intTupleDashedPrinter: Printer[(Int, Int)] = Printer.factory {
-    case (int1, int2) => int1.toString + "-" + int2.toString
+  implicit def intTupleDashedPrinter: Printer[(Int, Int)] = Printer.factory { case (int1, int2) =>
+    int1.toString + "-" + int2.toString
   }
 }

--- a/url-dsl/src/test/scala/urldsl/language/PathSegmentDummyErrorProperties.scala
+++ b/url-dsl/src/test/scala/urldsl/language/PathSegmentDummyErrorProperties.scala
@@ -1,16 +1,15 @@
 package urldsl.language
 
-
 import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll
 import urldsl.errors.DummyError.dummyErrorIsPathMatchingError
-final class PathSegmentDummyErrorProperties extends PathSegmentProperties(dummyErrorImpl, dummyErrorIsPathMatchingError, "PathSegmentDummyError") {
+final class PathSegmentDummyErrorProperties
+    extends PathSegmentProperties(dummyErrorImpl, dummyErrorIsPathMatchingError, "PathSegmentDummyError") {
 
   import dummyErrorImpl._
 
   property("filtering has no impact on generation with sugar") = forAll(Gen.choose(0, 1000)) { (x: Int) =>
     segment[Int].filter(_ < 0).createPath(x) == x.toString
   }
-
 
 }

--- a/url-dsl/src/test/scala/urldsl/language/PathSegmentSimpleErrorProperties.scala
+++ b/url-dsl/src/test/scala/urldsl/language/PathSegmentSimpleErrorProperties.scala
@@ -3,6 +3,9 @@ package urldsl.language
 import urldsl.errors.DummyError.dummyErrorIsPathMatchingError
 import urldsl.errors.SimplePathMatchingError
 
-final class PathSegmentSimpleErrorProperties extends PathSegmentProperties(simpleErrorImpl, SimplePathMatchingError.pathMatchingError, "PathSegmentSimpleError") {
-
-}
+final class PathSegmentSimpleErrorProperties
+    extends PathSegmentProperties(
+      simpleErrorImpl,
+      SimplePathMatchingError.pathMatchingError,
+      "PathSegmentSimpleError"
+    ) {}

--- a/url-dsl/src/test/scala/urldsl/language/PathSegmentWithQueryParamsChecks.scala
+++ b/url-dsl/src/test/scala/urldsl/language/PathSegmentWithQueryParamsChecks.scala
@@ -13,7 +13,7 @@ abstract class PathSegmentWithQueryParamsChecks[P, Q, F](
     pErrorFromThrowable: ErrorFromThrowable[P],
     qErrorFromThrowable: ErrorFromThrowable[Q],
     fErrorFromThrowable: ErrorFromThrowable[F],
-  pPathMatchingError: PathMatchingError[P]
+    pPathMatchingError: PathMatchingError[P]
 ) extends Properties(name) {
 
   import impl._

--- a/url-dsl/src/test/scala/urldsl/language/PathSegmentWithQueryParamsDummyErrorChecks.scala
+++ b/url-dsl/src/test/scala/urldsl/language/PathSegmentWithQueryParamsDummyErrorChecks.scala
@@ -1,7 +1,4 @@
 package urldsl.language
 
-final class PathSegmentWithQueryParamsDummyErrorChecks extends PathSegmentWithQueryParamsChecks(dummyErrorImpl, "PathSegmentWithQueryParamsDummyErrorChecks") {
-
-
-
-}
+final class PathSegmentWithQueryParamsDummyErrorChecks
+    extends PathSegmentWithQueryParamsChecks(dummyErrorImpl, "PathSegmentWithQueryParamsDummyErrorChecks") {}

--- a/url-dsl/src/test/scala/urldsl/language/PathSegmentWithQueryParamsSimpleErrorChecks.scala
+++ b/url-dsl/src/test/scala/urldsl/language/PathSegmentWithQueryParamsSimpleErrorChecks.scala
@@ -1,5 +1,4 @@
 package urldsl.language
 
-final class PathSegmentWithQueryParamsSimpleErrorChecks extends PathSegmentWithQueryParamsChecks(simpleErrorImpl, "PathSegmentWithQueryParamsSimpleErrorChecks") {
-
-}
+final class PathSegmentWithQueryParamsSimpleErrorChecks
+    extends PathSegmentWithQueryParamsChecks(simpleErrorImpl, "PathSegmentWithQueryParamsSimpleErrorChecks") {}

--- a/url-dsl/src/test/scala/urldsl/language/QueryParameterProperties.scala
+++ b/url-dsl/src/test/scala/urldsl/language/QueryParameterProperties.scala
@@ -44,8 +44,10 @@ final class QueryParameterProperties extends Properties("QueryParameters") {
 
     val intParam = param[Int]("x").filter(predicate)
 
-    Prop(intParam.matchParams(params) ==
-      (if (predicate(x)) Right(ParamMatchOutput(x, Map())) else Left(DummyError.dummyError))) && Prop(
+    Prop(
+      intParam.matchParams(params) ==
+        (if (predicate(x)) Right(ParamMatchOutput(x, Map())) else Left(DummyError.dummyError))
+    ) && Prop(
       intParam.createParams(x) == params
     )
   }

--- a/url-dsl/src/test/scala/urldsl/language/QueryParameterSpec.scala
+++ b/url-dsl/src/test/scala/urldsl/language/QueryParameterSpec.scala
@@ -11,7 +11,10 @@ final class QueryParameterSpec extends munit.FunSuite {
   import impl._
 
   test("Matching the empty list works") {
-    assertEquals(listParam[Int]("my-list").matchParams(Map("my-list" -> Param(Nil))), Right(ParamMatchOutput(List.empty[Int], Map.empty)))
+    assertEquals(
+      listParam[Int]("my-list").matchParams(Map("my-list" -> Param(Nil))),
+      Right(ParamMatchOutput(List.empty[Int], Map.empty))
+    )
   }
 
   test("Matching single element when list of param is empty fails") {

--- a/url-dsl/src/test/scala/urldsl/language/QueryParamsUrlSpec.scala
+++ b/url-dsl/src/test/scala/urldsl/language/QueryParamsUrlSpec.scala
@@ -29,7 +29,7 @@ final class QueryParamsUrlSpec extends AnyFlatSpec with Matchers {
     (param[String]("name") & param[Int]("age").?).params("Hello", Some(1)) should be("name=Hello&age=1")
     (param[String]("name") & param[String]("cat").?).params("Hello", Some("")) should be("name=Hello&cat=")
     (param[String]("name") & param[String]("cat").?).params("Hello", Some("Fluffy")) should be("name=Hello&cat=Fluffy")
-    
+
     // demonstrates quasi commutativity
     (listParam[Int]("ages") & param[String]("name")).params(List(32, 23), "Bob") should be(
       "ages=32&ages=23&name=Bob"

--- a/url-dsl/src/test/scala/urldsl/vocabulary/FromStringChecks.scala
+++ b/url-dsl/src/test/scala/urldsl/vocabulary/FromStringChecks.scala
@@ -14,7 +14,8 @@ object FromStringChecks extends Properties("FromStringChecks") {
 
   property("Decoding non-boolean string leads to error") = forAll(Gen.asciiStr) { (s: String) =>
     Try(s.toBoolean) match {
-      case Failure(throwable) => FromString[Boolean, DummyError].fromString(s) == Left(ErrorFromThrowable[DummyError].fromThrowable(throwable))
+      case Failure(throwable) =>
+        FromString[Boolean, DummyError].fromString(s) == Left(ErrorFromThrowable[DummyError].fromThrowable(throwable))
       case Success(_) => true
     }
   }

--- a/url-dsl/src/test/scala/urldsl/vocabulary/PrinterChecks.scala
+++ b/url-dsl/src/test/scala/urldsl/vocabulary/PrinterChecks.scala
@@ -10,12 +10,18 @@ object PrinterChecks extends Properties("PrinterChecks") {
   def checkPrinterToString[T](t: T, printer: Printer[T]): Prop = Prop(t.toString == printer(t))
 
   property("strings are printed as is") = forAll(someStringGen)(checkPrinterToString(_, Printer.stringPrinter))
-  property("ints are printed with toString") = forAll(Arbitrary.arbitrary[Int])(checkPrinterToString(_, Printer.intPrinter))
-  property("longs are printed with toString") = forAll(Arbitrary.arbitrary[Long])(checkPrinterToString(_, Printer.longPrinter))
-  property("booleans are printed with toString") = forAll(Gen.oneOf(true, false))(checkPrinterToString(_, Printer.booleanPrinter))
-  property("doubles are printed with toString") = forAll(Arbitrary.arbitrary[Double])(checkPrinterToString(_, Printer.doublePrinter))
-  property("big intss are printed with toString") = forAll(Arbitrary.arbitrary[BigInt])(checkPrinterToString(_, Printer.bigIntPrinter))
-  property("floats are printed with toString") = forAll(Arbitrary.arbitrary[Float])(checkPrinterToString(_, Printer.floatPrinter))
+  property("ints are printed with toString") =
+    forAll(Arbitrary.arbitrary[Int])(checkPrinterToString(_, Printer.intPrinter))
+  property("longs are printed with toString") =
+    forAll(Arbitrary.arbitrary[Long])(checkPrinterToString(_, Printer.longPrinter))
+  property("booleans are printed with toString") =
+    forAll(Gen.oneOf(true, false))(checkPrinterToString(_, Printer.booleanPrinter))
+  property("doubles are printed with toString") =
+    forAll(Arbitrary.arbitrary[Double])(checkPrinterToString(_, Printer.doublePrinter))
+  property("big intss are printed with toString") =
+    forAll(Arbitrary.arbitrary[BigInt])(checkPrinterToString(_, Printer.bigIntPrinter))
+  property("floats are printed with toString") =
+    forAll(Arbitrary.arbitrary[Float])(checkPrinterToString(_, Printer.floatPrinter))
 
   property("summoner method is called") = forAll(Gen.const(()))(_ => Printer[String] != null)
 


### PR DESCRIPTION
This matches the behaviour of the `creating`, which returns "" if the `listParam` is `Nil`.